### PR TITLE
feat: r-factor v0.2.1: split prepare_beams and y function

### DIFF
--- a/tleedmlib/wrapped/Makefile
+++ b/tleedmlib/wrapped/Makefile
@@ -25,7 +25,7 @@ interpolation.so: $(BUILD_DIR)/interpolation.pyf $(BUILD_DIR)/interpolation.o $(
 
 $(BUILD_DIR)/rfactor.pyf: $(SRC_DIR)/rfactor/rfactor.f90
 	mkdir -p $(BUILD_DIR)/
-	f2py -m rfactor $(SRC_DIR)/rfactor/rfactor.f90 -h $(BUILD_DIR)/rfactor.pyf --overwrite-signature --debug-capi only: prepare_beams r_pendry_beam_y r_pendry_beamset_y r_beamset_v0r_opt_on_grid parabola_lsq_fit parabola parabola_r_squared r_beamtype_grouping r2_beam_intensity r2_beamset_intensity apply_beamset_shift trapez_integration_const_dx tenser_intsum r_pendry_beam_y_wrong test_compilation
+	f2py -m rfactor $(SRC_DIR)/rfactor/rfactor.f90 -h $(BUILD_DIR)/rfactor.pyf --overwrite-signature --debug-capi only: prepare_beams r_pendry_beam_y r_pendry_beamset_y r_beamset_v0r_opt_on_grid parabola_lsq_fit parabola parabola_r_squared r_beamtype_grouping r2_beam_intensity r2_beamset_intensity apply_beamset_shift trapez_integration_const_dx tenser_intsum r_pendry_beam_y_wrong test_compilation pendry_y_beamset pendry_y alloc_beams_arrays
 $(BUILD_DIR)/interpolation.pyf: $(SRC_DIR)/interpolation/interpolation.f90
 	mkdir -p $(BUILD_DIR)/
 	f2py -m interpolation $(SRC_DIR)/interpolation/interpolation.f90 -h $(BUILD_DIR)/interpolation.pyf --overwrite-signature --debug-capi only: get_array_sizes de_Boor_size single_calc_spline pre_eval_input_grid calc_spline_with_pre_eval single_interpolate_coeffs_to_grid get_intervals calc_deBoor eval_bspline_fast

--- a/tleedmlib/wrapped/error_codes.py
+++ b/tleedmlib/wrapped/error_codes.py
@@ -38,6 +38,8 @@ error_codes = {
     # 7xx : other in prepare
     701: "Unknown R factor requested. Only Pendry(1) and R2(2) are allowed.",
     702: "Invalid data passed to V0r optimization. Check if correct R factor is selected.",
+    703: "In prepare_beams: more derivatives requested than are available.",
+    704: "2nd derivative is not implemented yet", #2nd derivative will likely be needed in the future
     # 8: R-factor
     811: "At least one R-factor returned as NaN",
     851: "V0r optimization range too small",

--- a/viperleed_from_ase.py
+++ b/viperleed_from_ase.py
@@ -433,44 +433,78 @@ def rfactor_from_csv(
     grid = np.arange(minen, maxen + intpol_step, intpol_step)
 
     averaging_scheme = np.int32(np.arange(n_beams) + 1)  # don't average
+    n_derivs = 1
 
     # interpolate and prepare beam arrays
+
+    # initialize beam arrays
     (
         beams1_e_start_beams_out,
         beams1_n_e_beams_out,
-        beams1_intpol_intensity,  # may be needed for R2
-        beams1_yfunc,
+        beams1_intpol_intensity,
+        beams1_deriv_y,
         ierr,
-    ) = rf.prepare_beams(
+    ) = rf.alloc_beams_arrays(n_beams, len(grid))
+    _check_ierr(ierr)
+
+    ierr = rf.prepare_beams(
         beams1_en,
         beams1_arr,
         beams1_id_start + 1,
         beams1_n_E_beams,
-        which_r,
         intpol_deg,
+        n_derivs,
         grid,
         v0i,
+        beams1_e_start_beams_out,
+        beams1_n_e_beams_out,
+        beams1_intpol_intensity,
+        beams1_deriv_y,
     )
     _check_ierr(ierr)
 
+    rf.pendry_y_beamset(
+        beams1_intpol_intensity,
+        beams1_deriv_y,
+        beams1_id_start + 1,
+        beams1_n_e_beams_out,
+        v0i
+    )
+
+    # Beams 2
     (
         beams2_e_start_beams_out,
         beams2_n_e_beams_out,
-        beams2_intpol_intensity,  # may be needed for R2
-        beams2_yfunc,
+        beams2_intpol_intensity,
+        beams2_deriv_y,
         ierr,
-    ) = rf.prepare_beams(
+    ) = rf.alloc_beams_arrays(n_beams, len(grid))
+    _check_ierr(ierr)
+
+    ierr = rf.prepare_beams(
         beams2_en,
         beams2_arr,
         beams2_id_start + 1,
         beams2_n_E_beams,
-        which_r,
         intpol_deg,
+        n_derivs,
         grid,
         v0i,
+        beams2_e_start_beams_out,
+        beams2_n_e_beams_out,
+        beams2_intpol_intensity,
+        beams2_deriv_y,
+
     )
-    #return beams1_yfunc
     _check_ierr(ierr)
+
+    rf.pendry_y_beamset(
+        beams2_intpol_intensity,
+        beams2_deriv_y,
+        beams2_id_start +1 ,
+        beams2_n_e_beams_out,
+        v0i
+    )
     
     # Ready to calculate R-factor
     v0r_shift_range_int = np.int32([round(v / intpol_step) for v in v0r_shift_range])
@@ -489,8 +523,8 @@ def rfactor_from_csv(
         start_guess,
         fast_search,
         intpol_step,
-        beams1_yfunc,
-        beams2_yfunc,
+        beams1_deriv_y,
+        beams2_deriv_y,
         beams1_e_start_beams_out,
         beams2_e_start_beams_out,
         beams1_n_e_beams_out,


### PR DESCRIPTION
Signatures are changed to allow more reuse of arrays without reallocation.
Use new alloc_beams_arrays once in the beginning and then save the allocation time on every single call of the r-factor.
Prepare beams now returns interpolated intensities and derivatives, but not the y function. The y function can be called on these and overwrites the derivative array.