### PR TITLE
feat: move matplotlib import and use different font type

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,8 @@
 =================
 '''
 
-# print('You have imported', __name__)
 
 GLOBALS = {'USE_GUI': None,
+           'CAN_PLOT': None,
            'version': '0.9.0', }
+

--- a/tleedmlib/base.py
+++ b/tleedmlib/base.py
@@ -18,6 +18,8 @@ import itertools
 
 logger = logging.getLogger("tleedm.base")
 
+from viperleed import GLOBALS
+
 
 ###############################################
 #                 CLASSES                     #
@@ -611,25 +613,14 @@ def make_unique_list(w_duplicates):
             unique_list.append(item)
     return unique_list
 
-def get_matplotlib():
-    try:
-        import matplotlib
-        import matplotlib.pyplot as plt
-    except ImportError:
-        return None
+
+def set_matplotlib_rc(matplotlib):
+    if not GLOBALS['CAN_PLOT']:
+        raise ImportError("Cannot set up matplotlib before importing it.")
 
     matplotlib.rcParams.update({'figure.max_open_warning': 0})
     matplotlib.use('Agg')  # TODO: check with Michele if this causes conflicts
     # set fonttype 42 so Pdfs are editable
     matplotlib.rcParams['pdf.fonttype'] = 42
-    # import matplotlib.ticker as plticker
+    matplotlib.rcParams['ps.fonttype'] = 42
     matplotlib.rcParams["mathtext.default"] = "regular"
-    return plt
-
-
-def get_matplotlib_pdfpages():
-    try:
-        from matplotlib.backends.backend_pdf import PdfPages
-    except ImportError:
-        return None
-    return PdfPages

--- a/tleedmlib/classes/rparams.py
+++ b/tleedmlib/classes/rparams.py
@@ -16,16 +16,26 @@ import shutil
 from timeit import default_timer as timer
 from pathlib import Path
 
+from viperleed import GLOBALS
 from viperleed.tleedmlib.files.iodeltas import checkDelta
 from viperleed.tleedmlib.leedbase import getMaxTensorIndex
-from viperleed.tleedmlib.base import available_cpu_count, get_matplotlib
+from viperleed.tleedmlib.base import available_cpu_count, set_matplotlib_rc
 from viperleed.tleedmlib.checksums import (
     KNOWN_TL_VERSIONS,
     UnknownTensErLEEDVersionError
 )
 
-plt = get_matplotlib()
-plotting = True if plt else False
+try:
+    import matplotlib
+except ImportError:
+    GLOBALS['CAN_PLOT'] = False
+else:
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+    GLOBALS['CAN_PLOT'] = True
+    set_matplotlib_rc(matplotlib)
+
+plotting = GLOBALS['CAN_PLOT']
 
 logger = logging.getLogger("tleedm.rparams")
 

--- a/tleedmlib/files/ioerrorcalc.py
+++ b/tleedmlib/files/ioerrorcalc.py
@@ -13,11 +13,21 @@ import re
 from scipy import interpolate
 from zipfile import ZipFile, ZIP_DEFLATED
 
-from viperleed.tleedmlib.base import range_to_str, max_diff, get_matplotlib, get_matplotlib_pdfpages
+from viperleed import GLOBALS
+from viperleed.tleedmlib.base import range_to_str, max_diff, set_matplotlib_rc
 
-plt = get_matplotlib()
-plotting = True if plt else False
-PdfPages = get_matplotlib_pdfpages()
+# try to import matplotlib
+try:
+    import matplotlib
+except ImportError:
+    GLOBALS['CAN_PLOT'] = False
+else:
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+    GLOBALS['CAN_PLOT'] = True
+    set_matplotlib_rc(matplotlib)
+
+plotting = GLOBALS['CAN_PLOT']
 
 logger = logging.getLogger("tleedm.files.ioerrorcalc")
 logger.setLevel(logging.INFO)

--- a/tleedmlib/files/iofdopt.py
+++ b/tleedmlib/files/iofdopt.py
@@ -12,14 +12,23 @@ import logging
 import copy
 from numpy.polynomial import Polynomial
 
+from viperleed import GLOBALS
 from viperleed.tleedmlib.files.iorfactor import read_rfactor_columns
 from viperleed.tleedmlib.files.ivplot import plot_iv
-from viperleed.tleedmlin.base import get_matplotlib, get_matplotlib_pdfpages
+from viperleed.tleedmlib.base import set_matplotlib_rc
 
-plt = get_matplotlib()
-plotting = True if plt else False
-PdfPages = get_matplotlib_pdfpages()
+# try to import matplotlib
+try:
+    import matplotlib
+except ImportError:
+    GLOBALS['CAN_PLOT'] = False
+else:
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+    GLOBALS['CAN_PLOT'] = True
+    set_matplotlib_rc(matplotlib)
 
+plotting = GLOBALS['CAN_PLOT']
 logger = logging.getLogger("tleedm.files.iofdout")
 logger.setLevel(logging.INFO)
 
@@ -211,7 +220,7 @@ def write_fd_opt_beams_pdf(rp, points, which, tmpdirs, best_rfactors,
               for b in rp.expbeams]
     formatting = copy.deepcopy(rp.PLOT_IV)  # use to set colors
     formatting['colors'] = (
-        list(cm.get_cmap('viridis', len(points)).colors)
+        list(matplotlib.cm.get_cmap('viridis', len(points)).colors)
         + [np.array([0, 0, 0, 1])])
     formatting['linewidths'] = [0.5] * len(points) + [1.]
     formatting['linewidths'][best_point_ind] = 1.

--- a/tleedmlib/files/iorfactor.py
+++ b/tleedmlib/files/iorfactor.py
@@ -14,16 +14,24 @@ import os
 
 import fortranformat as ff
 
+from viperleed import GLOBALS
 from viperleed.tleedmlib.files.beams import writeAUXEXPBEAMS
 from viperleed.tleedmlib.leedbase import getBeamCorrespondence, getYfunc
 from viperleed.tleedmlib.files.ivplot import plot_iv
-from viperleed.tleedmlib.base import get_matplotlib, get_matplotlib PdfPages
+from viperleed.tleedmlib.base import set_matplotlib_rc
 
+# try to import matplotlib
+try:
+    import matplotlib
+except ImportError:
+    GLOBALS['CAN_PLOT'] = False
+else:
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+    GLOBALS['CAN_PLOT'] = True
+    set_matplotlib_rc(matplotlib)
 
-plt = get_matplotlib()
-plotting = True if plt else False
-PdfPages = get_matplotlib_pdfpages()
-
+plotting = GLOBALS['CAN_PLOT']
 logger = logging.getLogger("tleedm.files.iorfactor")
 
 
@@ -504,7 +512,7 @@ def prepare_analysis_plot(formatting, xyExp, xyTheo):
     dy = ymax - ymin
     # set ticks spacing to 50 eV and round the x limits to a multiple of it
     tick = 50
-    oritick = plticker.MultipleLocator(base=tick)
+    oritick = matplotlib.ticker.MultipleLocator(base=tick)
     xlims = (np.floor(xmin / tick) * tick,
              np.ceil(xmax / tick) * tick)
     dx = xlims[1] - xlims[0]

--- a/tleedmlib/files/ivplot.py
+++ b/tleedmlib/files/ivplot.py
@@ -8,13 +8,22 @@ Created on Mon Oct 25 18:47:39 2021
 import logging
 import numpy as np
 
-
+from viperleed import GLOBALS
 import viperleed.tleedmlib as tl
-from viperleed.tleedmlib.base import get_matplotlib, get_matplotlib_pdfpages
+from viperleed.tleedmlib.base import set_matplotlib_rc
 
-plt = get_matplotlib()
-plotting = True if plt else False
-PdfPages = get_matplotlib_pdfpages()
+# try to import matplotlib
+try:
+    import matplotlib
+except ImportError:
+    GLOBALS['CAN_PLOT'] = False
+else:
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+    GLOBALS['CAN_PLOT'] = True
+    set_matplotlib_rc(matplotlib)
+
+plotting = GLOBALS['CAN_PLOT']
 
 logger = logging.getLogger("tleedm.files.ivplot")
 
@@ -176,7 +185,7 @@ def plot_iv(data, filename, labels=[], annotations=[],
 
     # set ticks spacing to 50 eV and round the x limits to a multiple of it
     tick = 50
-    oritick = plticker.MultipleLocator(base=tick)
+    oritick = matplotlib.ticker.MultipleLocator(base=tick)
     majortick = oritick
     minortick = None
     xlims = (np.floor(xmin/tick)*tick,
@@ -194,7 +203,7 @@ def plot_iv(data, filename, labels=[], annotations=[],
     if dx / (tick * fontscale) > 16:  # too many labelled ticks
         minortick = majortick
         newbase = int(np.ceil(dx / (tick * fontscale * 16))) * tick
-        majortick = plticker.MultipleLocator(base=newbase)
+        majortick = matplotlib.ticker.MultipleLocator(base=newbase)
     ticklen = 3*fontscale
 
     # axes helper variables

--- a/tleedmlib/files/phaseshifts.py
+++ b/tleedmlib/files/phaseshifts.py
@@ -15,13 +15,21 @@ from pathlib import Path
 
 import fortranformat as ff
 
+from viperleed import GLOBALS
 from viperleed.tleedmlib.leedbase import (get_atomic_number,
                                           get_element_symbol)
-from viperleed.tleedmlib.base import get_matplotlib, get_matplotlin_pdfpages
+from viperleed.tleedmlib.base import set_matplotlib_rc
 
-plt = get_matplotlib()
-_CAN_PLOT = True if plt else False
-PdfPages = get_matplotlib_pdfpages()
+# try to import matplotlib
+try:
+    import matplotlib
+except ImportError:
+    GLOBALS['CAN_PLOT'] = False
+else:
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+    GLOBALS['CAN_PLOT'] = True
+    set_matplotlib_rc(matplotlib)
 
 logger = logging.getLogger("tleedm.files.phaseshifts")
 _HARTREE_TO_EV = 27.211396
@@ -514,7 +522,7 @@ def plot_phaseshifts(sl, rp, filename="Phaseshifts_plots.pdf"):
     -------
     None.
     """
-    if not _CAN_PLOT:
+    if not GLOBALS['CAN_PLOT']:
         logger.debug("Necessary modules for plotting not found. Skipping "
                      "Phaseshift plotting.")
         return

--- a/tleedmlib/files/searchpdf.py
+++ b/tleedmlib/files/searchpdf.py
@@ -11,14 +11,23 @@ import numpy as np
 import logging
 from matplotlib.markers import MarkerStyle
 
+from viperleed import GLOBALS
+from viperleed.tleedmlib.base import set_matplotlib_rc
+
+# try to import matplotlib
+try:
+    import matplotlib
+except ImportError:
+    GLOBALS['CAN_PLOT'] = False
+else:
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+    GLOBALS['CAN_PLOT'] = True
+    set_matplotlib_rc(matplotlib)
+
+plotting = GLOBALS['CAN_PLOT']
 logger = logging.getLogger("tleedm.files.searchpdf")
 logger.setLevel(logging.INFO)
-
-from viperleed.tleedmlib.base import get_matplotlib, get_matplotlib_pdfpages
-
-plt = get_matplotlib()
-plotting = True if plt else False
-PdfPages = get_matplotlib_pdfpages()
 
 def writeSearchProgressPdf(rp, gens, rfacs, lastconfig,
                            outname="Search-progress.pdf",


### PR DESCRIPTION
As pointed out by Alexander Schneider, plots produced by ViPErLEED are currently not editable in most PDF editors. To enable this, we need to change the default font type used by matplotlib to type 42. (See also here: [https://jdhao.github.io/2018/01/18/mpl-plotting-notes-201801/#type-3-font-used-by-matplotlib-pdf-backend](url))

I changed this default and moved the repeated check for matplotlib import to two functions in the base file.
Other suggestions are welcome.