### PR TITLE
Fix phaseshift consistency check

### DIFF
--- a/src/viperleed/calc/files/phaseshifts.py
+++ b/src/viperleed/calc/files/phaseshifts.py
@@ -440,10 +440,12 @@ def __check_consitency_element_order(rp, sl, phaseshifts,
         if all(abs(ps_sites) > eps):
             break
     else:
-        # None of the phaseshifts are larger than eps at this energy
+        # At least one of the phaseshifts are smaller than eps at this energy
         logger.warning(
-            "Could not check consistency of PHASESHIFTS file: All "
-            f"PHASESHIFTS are smaller than {eps} at the largest energy."
+            "Could not check consistency of PHASESHIFTS file: "
+            f"PHASESHIFTS for some sites are smaller than {eps} at the largest "
+            "energy for LMAX > {l_max_cutoff}. This may happen if you are "
+            "using very light scatterers."
             )
         rp.setHaltingLevel(1)
         return

--- a/src/viperleed/calc/files/phaseshifts.py
+++ b/src/viperleed/calc/files/phaseshifts.py
@@ -370,7 +370,7 @@ def __check_consistency_energy_range(rp, phaseshifts, muftin, newpsGen):
 
 
 def __check_consitency_element_order(rp, sl, phaseshifts,
-                                     eps=None, l_max_cutoff=4):
+                                     eps=None, l_max_cutoff=3):
     """Determine if elements may have been assigned wrong phaseshifts.
 
     In general at high energies and at high LMAX, heavier elements
@@ -402,7 +402,7 @@ def __check_consitency_element_order(rp, sl, phaseshifts,
         higher phaseshifts in the limit of high energy and high angular
         momentum. Behaviour for low energy/low angular momentum is not
         as clear cut, as phaseshifts may cross zero and are pi periodic.
-        Default is 4.
+        Default is 3.
 
     Returns
     -------


### PR DESCRIPTION
@LutzHammer recently reported a small issue where our consistency check of the PHASESHIFTS file gives an erroneous warning message because the phaseshifts for Hydrogen (the lightest scatterer possible) were too small for proper comparison. This PR slightly adapts some comparison defaults and expands on the issued warning message.
