### PR TITLE
matplotlib: fix style in py3.7, other small improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ license = {file = 'LICENSE.md'}
 readme = 'README.md'
 dependencies = [
     'fortranformat',
-    'matplotlib',
+    'importlib_resources; python_version<"3.10"',  # Patch matplotlib
+    'matplotlib>=3.5',  # Maybe even lower, but had problems installing
     'numpy',
     'psutil',
     'quicktions',

--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -25,13 +25,6 @@ import random
 import shutil
 from timeit import default_timer as timer
 
-try:
-    import matplotlib.pyplot as plt
-except ImportError:
-    _CAN_PLOT = False
-else:
-    _CAN_PLOT = True
-
 import numpy as np
 
 from viperleed.calc.classes.searchpar import SearchPar
@@ -43,6 +36,9 @@ from viperleed.calc.lib.base import parent_name
 from viperleed.calc.lib.checksums import KNOWN_TL_VERSIONS
 from viperleed.calc.lib.checksums import UnknownTensErLEEDVersionError
 from viperleed.calc.sections.calc_section import EXPBEAMS_NAMES
+from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
+from viperleed.calc.lib.matplotlib_utils import skip_without_matplotlib
+from viperleed.calc.lib.matplotlib_utils import use_calc_style
 from viperleed.calc.lib.version import Version
 from viperleed.calc.files.tenserleed import get_tenserleed_sources
 
@@ -53,8 +49,9 @@ from .special.base import SpecialParameter
 
 
 _LOGGER = logging.getLogger(parent_name(__name__))
-if _CAN_PLOT:
-    plt.style.use('viperleed.calc')
+if CAN_PLOT:
+    import matplotlib.pyplot as plt
+    use_calc_style()
 
 
 class Rparams:
@@ -846,6 +843,7 @@ class Rparams:
             return []
         return self.renormalizeDomainParams(out)
 
+    @skip_without_matplotlib
     def closePdfReportFigs(self):
         """
         Closes the pdf figures from the Search-progress pdf files, which are
@@ -855,9 +853,6 @@ class Rparams:
         -------
         None.
         """
-        if not _CAN_PLOT:
-            return
-
         for figures in self.lastParScatterFigs.values():
             for figure in figures:
                 try:

--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -37,6 +37,7 @@ from viperleed.calc.lib.checksums import KNOWN_TL_VERSIONS
 from viperleed.calc.lib.checksums import UnknownTensErLEEDVersionError
 from viperleed.calc.sections.calc_section import EXPBEAMS_NAMES
 from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
+from viperleed.calc.lib.matplotlib_utils import close_figures
 from viperleed.calc.lib.matplotlib_utils import skip_without_matplotlib
 from viperleed.calc.lib.matplotlib_utils import use_calc_style
 from viperleed.calc.lib.version import Version
@@ -854,11 +855,7 @@ class Rparams:
         None.
         """
         for figures in self.lastParScatterFigs.values():
-            for figure in figures:
-                try:
-                    plt.close(figure)
-                except Exception:
-                    pass
+            close_figures(plt, *figures)
 
     def generateSearchPars(self, sl, subdomain=False):
         """

--- a/src/viperleed/calc/files/ioerrorcalc.py
+++ b/src/viperleed/calc/files/ioerrorcalc.py
@@ -22,6 +22,7 @@ from scipy import interpolate
 from viperleed.calc.lib.base import max_diff
 from viperleed.calc.lib.base import range_to_str
 from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
+from viperleed.calc.lib.matplotlib_utils import close_figures
 from viperleed.calc.lib.matplotlib_utils import log_without_matplotlib
 from viperleed.calc.lib.matplotlib_utils import prepare_matplotlib_for_calc
 
@@ -595,8 +596,4 @@ def write_errors_pdf(figs, filename="Errors.pdf"):
             pdf.close()
         except Exception:
             pass
-    for fig in figs:
-        try:
-            plt.close(fig)
-        except Exception:
-            pass
+    close_figures(plt, *figs)

--- a/src/viperleed/calc/files/ioerrorcalc.py
+++ b/src/viperleed/calc/files/ioerrorcalc.py
@@ -21,19 +21,14 @@ from scipy import interpolate
 
 from viperleed.calc.lib.base import max_diff
 from viperleed.calc.lib.base import range_to_str
+from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
+from viperleed.calc.lib.matplotlib_utils import log_without_matplotlib
+from viperleed.calc.lib.matplotlib_utils import prepare_matplotlib_for_calc
 
-
-try:
-    import matplotlib
-    matplotlib.rcParams.update({'figure.max_open_warning': 0})
-    matplotlib.use('Agg')  # !!! check with Michele if this causes conflicts
+if CAN_PLOT:
+    prepare_matplotlib_for_calc()
     from matplotlib.backends.backend_pdf import PdfPages
     import matplotlib.pyplot as plt
-    plt.style.use('viperleed.calc')
-except Exception:
-    _CAN_PLOT = False
-else:
-    _CAN_PLOT = True
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -296,6 +291,7 @@ def format_col_content(content):
                          f" file: {content}")
 
 
+@log_without_matplotlib(logger, msg='Skipping error plotting.')
 def make_errors_figs(errors, formatting=None):
     """Creates figures for Errors.pdf.
 
@@ -307,12 +303,6 @@ def make_errors_figs(errors, formatting=None):
         Dictionary containing formatting options for the plots.
         To be taken from rparams.PLOT_IV. The default is None.
     """
-    global _CAN_PLOT
-    if not _CAN_PLOT:
-        logger.debug("Necessary modules for plotting not found. Skipping "
-                     "error plotting.")
-        return
-
     # check formatting
     if formatting is None:
         formatting = {}

--- a/src/viperleed/calc/files/iofdopt.py
+++ b/src/viperleed/calc/files/iofdopt.py
@@ -16,6 +16,7 @@ from numpy.polynomial import Polynomial
 from viperleed.calc.files.iorfactor import read_rfactor_columns
 from viperleed.calc.files.ivplot import plot_iv
 from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
+from viperleed.calc.lib.matplotlib_utils import close_figures
 from viperleed.calc.lib.matplotlib_utils import log_without_matplotlib
 from viperleed.calc.lib.matplotlib_utils import prepare_matplotlib_for_calc
 
@@ -135,11 +136,7 @@ def write_fd_opt_pdf(points, which, filename="FD_Optimization.pdf",
             pdf.close()
         except Exception:
             pass
-    try:
-        plt.close(fig)
-    except Exception:
-        pass
-    return
+    close_figures(plt, fig)
 
 
 def write_fd_opt_beams_pdf(rp, points, which, tmpdirs, best_rfactors,

--- a/src/viperleed/calc/files/iofdopt.py
+++ b/src/viperleed/calc/files/iofdopt.py
@@ -13,21 +13,17 @@ import logging
 import numpy as np
 from numpy.polynomial import Polynomial
 
-try:
-    import matplotlib
-    matplotlib.rcParams.update({'figure.max_open_warning': 0})
-    matplotlib.use('Agg')  # !!! check with Michele if this causes conflicts
-    from matplotlib.backends.backend_pdf import PdfPages
-    import matplotlib.pyplot as plt
-    plt.style.use('viperleed.calc')
-    from matplotlib import cm
-except Exception:
-    _CAN_PLOT = False
-else:
-    _CAN_PLOT = True
-
 from viperleed.calc.files.iorfactor import read_rfactor_columns
 from viperleed.calc.files.ivplot import plot_iv
+from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
+from viperleed.calc.lib.matplotlib_utils import log_without_matplotlib
+from viperleed.calc.lib.matplotlib_utils import prepare_matplotlib_for_calc
+
+if CAN_PLOT:
+    prepare_matplotlib_for_calc()
+    from matplotlib.backends.backend_pdf import PdfPages
+    import matplotlib.pyplot as plt
+    from matplotlib import cm
 
 
 logger = logging.getLogger(__name__)
@@ -74,6 +70,7 @@ def write_fd_opt_csv(points, which, filename="FD_Optimization.csv", sep=","):
     return
 
 
+@log_without_matplotlib(logger, msg='Skipping error plotting.')
 def write_fd_opt_pdf(points, which, filename="FD_Optimization.pdf",
                      parabola=None):
     """
@@ -95,12 +92,6 @@ def write_fd_opt_pdf(points, which, filename="FD_Optimization.pdf",
     None.
 
     """
-
-    global _CAN_PLOT
-    if not _CAN_PLOT:
-        logger.debug("Necessary modules for plotting not found. Skipping "
-                     "error plotting.")
-        return
     title = which
     if which in ["a", "b", "c", "ab", "abc"]:
         title += " scaling"
@@ -177,8 +168,7 @@ def write_fd_opt_beams_pdf(rp, points, which, tmpdirs, best_rfactors,
 
     """
 
-    global _CAN_PLOT
-    if not _CAN_PLOT:
+    if not CAN_PLOT:
         logger.debug("Necessary modules for plotting not found. Skipping "
                      "error plotting.")
         return

--- a/src/viperleed/calc/files/ivplot.py
+++ b/src/viperleed/calc/files/ivplot.py
@@ -12,24 +12,22 @@ import logging
 
 import numpy as np
 
-try:
-    import matplotlib
-except Exception:
-    _CAN_PLOT = False
-else:
-    _CAN_PLOT = True
-    matplotlib.rcParams.update({'figure.max_open_warning': 0})
-    matplotlib.use('Agg')  # !!! check with Michele if this causes conflicts
+from viperleed.calc.classes.beam import Beam
+from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
+from viperleed.calc.lib.matplotlib_utils import log_without_matplotlib
+from viperleed.calc.lib.matplotlib_utils import prepare_matplotlib_for_calc
+
+if CAN_PLOT:
+    prepare_matplotlib_for_calc()
     from matplotlib.backends.backend_pdf import PdfPages
+    from matplotlib.colors import is_color_like
     import matplotlib.pyplot as plt
     import matplotlib.ticker as plticker
-    plt.style.use('viperleed.calc')
-
-from viperleed.calc.classes.beam import Beam
 
 logger = logging.getLogger(__name__)
 
 
+@log_without_matplotlib(logger, msg='Skipping R-factor plotting.')
 def plot_iv(data, filename, labels=[], annotations=[],
             legends=[], formatting={}):
     '''
@@ -85,12 +83,6 @@ def plot_iv(data, filename, labels=[], annotations=[],
     None
 
     '''
-    global _CAN_PLOT
-    if not _CAN_PLOT:
-        logger.debug("Necessary modules for plotting not found. Skipping "
-                     "R-factor plotting.")
-        return
-
     # check data
     if type(data) not in (list, tuple):
         raise TypeError("Expected data as a list or tuple, found "
@@ -269,8 +261,7 @@ def plot_iv(data, filename, labels=[], annotations=[],
                     if minortick is not None:
                         ax.tick_params(which='minor', length=ticklen*0.5)
             if plot_colors:
-                if not all([matplotlib.colors.is_color_like(s)
-                            for s in plot_colors]):
+                if not all(is_color_like(s) for s in plot_colors):
                     plot_colors = []
                     logger.warning("plot_iv: Specified colors not "
                                    "recognized, reverting to default colors")

--- a/src/viperleed/calc/files/phaseshifts.py
+++ b/src/viperleed/calc/files/phaseshifts.py
@@ -17,20 +17,16 @@ import fortranformat as ff
 import numpy as np
 
 from viperleed.calc.lib.leedbase import HARTREE_TO_EV
+from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
+from viperleed.calc.lib.matplotlib_utils import log_without_matplotlib
+from viperleed.calc.lib.matplotlib_utils import prepare_matplotlib_for_calc
 from viperleed.calc.lib.periodic_table import (get_atomic_number,
                                                get_element_symbol)
 
-try:
-    import matplotlib
-except ImportError:
-    _CAN_PLOT = False
-else:
-    matplotlib.rcParams.update({'figure.max_open_warning': 0})
-    matplotlib.use('Agg')
+if CAN_PLOT:
+    prepare_matplotlib_for_calc()
     from matplotlib.backends.backend_pdf import PdfPages
     import matplotlib.pyplot as plt
-    plt.style.use('viperleed.calc')
-    _CAN_PLOT = True
 
 
 logger = logging.getLogger(__name__)
@@ -510,6 +506,7 @@ def writePHASESHIFTS(firstline, phaseshifts, file_path=Path()/'PHASESHIFTS'):
     return
 
 
+@log_without_matplotlib(logger, msg='Skipping Phaseshift plotting.')
 def plot_phaseshifts(sl, rp, filename="Phaseshifts_plots.pdf"):
     """
     Outputs plots of the phaseshifts in rp.phaseshifts in a pdf file.
@@ -528,10 +525,6 @@ def plot_phaseshifts(sl, rp, filename="Phaseshifts_plots.pdf"):
     -------
     None.
     """
-    if not _CAN_PLOT:
-        logger.debug("Necessary modules for plotting not found. Skipping "
-                     "Phaseshift plotting.")
-        return
     ps_labels = []
     for el in sl.elements:
         # this reproduces the order of blocks contained in PHASESHIFTS:

--- a/src/viperleed/calc/files/searchpdf.py
+++ b/src/viperleed/calc/files/searchpdf.py
@@ -13,6 +13,7 @@ import logging
 import numpy as np
 
 from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
+from viperleed.calc.lib.matplotlib_utils import close_figures
 from viperleed.calc.lib.matplotlib_utils import prepare_matplotlib_for_calc
 from viperleed.calc.lib.matplotlib_utils import skip_without_matplotlib
 
@@ -433,11 +434,7 @@ def writeSearchProgressPdf(rp, gens, rfacs, lastconfig,
 
     # save
     if searchname in rp.lastParScatterFigs:
-        for f in rp.lastParScatterFigs[searchname]:
-            try:
-                plt.close(f)
-            except Exception:
-                pass
+        close_figures(plt, *rp.lastParScatterFigs[searchname])
     rp.lastParScatterFigs[searchname] = figs[1:]
     try:
         pdf = PdfPages(outname)
@@ -456,14 +453,10 @@ def writeSearchProgressPdf(rp, gens, rfacs, lastconfig,
             pdf.close()
         except Exception:
             pass
-    for fig in [f for f in figs if
-                searchname not in rp.lastParScatterFigs or
-                f not in rp.lastParScatterFigs[searchname]]:
-        try:
-            plt.close(fig)
-        except Exception:
-            pass
-    return None
+    figures = (f for f in figs
+               if searchname not in rp.lastParScatterFigs
+               or f not in rp.lastParScatterFigs[searchname])
+    close_figures(plt, *figures)
 
 
 @skip_without_matplotlib
@@ -592,8 +585,4 @@ def writeSearchReportPdf(rp, outname="Search-report.pdf"):
             pdf.close()
         except Exception:
             pass
-    try:
-        plt.close(fig)
-    except Exception:
-        pass
-    return None
+    close_figures(plt, fig)

--- a/src/viperleed/calc/files/searchpdf.py
+++ b/src/viperleed/calc/files/searchpdf.py
@@ -10,26 +10,24 @@ __license__ = 'GPLv3+'
 
 import logging
 
-from matplotlib.markers import MarkerStyle
 import numpy as np
 
-try:
-    import matplotlib
-    matplotlib.rcParams.update({'figure.max_open_warning': 0})
-    matplotlib.use('Agg')  # !!! check with Michele if this causes conflicts
+from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
+from viperleed.calc.lib.matplotlib_utils import prepare_matplotlib_for_calc
+from viperleed.calc.lib.matplotlib_utils import skip_without_matplotlib
+
+if CAN_PLOT:
+    prepare_matplotlib_for_calc()
     from matplotlib.backends.backend_pdf import PdfPages
     import matplotlib.pyplot as plt
-    plt.style.use('viperleed.calc')
-except Exception:
-    _CAN_PLOT = False
-else:
-    _CAN_PLOT = True
+    from matplotlib.markers import MarkerStyle
 
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+@skip_without_matplotlib
 def writeSearchProgressPdf(rp, gens, rfacs, lastconfig,
                            outname="Search-progress.pdf",
                            csvname="Search-progress.csv",
@@ -68,10 +66,6 @@ def writeSearchProgressPdf(rp, gens, rfacs, lastconfig,
     None.
 
     """
-    global _CAN_PLOT
-    if not _CAN_PLOT:
-        return None
-
     markers = markers or []
 
     figsPerPage = 5
@@ -472,6 +466,7 @@ def writeSearchProgressPdf(rp, gens, rfacs, lastconfig,
     return None
 
 
+@skip_without_matplotlib
 def writeSearchReportPdf(rp, outname="Search-report.pdf"):
     """
     Writes a pdf file with reports on R-factor convergence and parameter
@@ -489,9 +484,6 @@ def writeSearchReportPdf(rp, outname="Search-report.pdf"):
     None.
 
     """
-    global _CAN_PLOT
-    if not _CAN_PLOT:
-        return None
     allmin = []
     allmax = []
     allmean = []

--- a/src/viperleed/calc/lib/matplotlib_utils.py
+++ b/src/viperleed/calc/lib/matplotlib_utils.py
@@ -1,0 +1,130 @@
+"""Functions useful for handling matplotlib.
+
+In particular, stuff that makes new matplotlib features available in
+older python versions.
+"""
+
+__authors__ = (
+    'Michele Riva (@michele-riva)',
+    )
+__copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
+__created__ = '2024-07-10'
+__license__ = 'GPLv+3'
+
+from functools import wraps
+import sys
+
+if sys.version_info >= (3, 10):
+    import importlib.resources as importlib_resources
+else:
+    # According to matplotlib.style.core, even though Py3.9 has
+    # importlib.resources, it doesn't properly handle modules
+    # added in sys.path.
+    import importlib_resources
+
+try:
+    from matplotlib import __version__ as mpl_version
+except ModuleNotFoundError:
+    CAN_PLOT = False
+else:
+    import matplotlib
+    from matplotlib import _rc_params_in_file
+    from matplotlib import style as mpl_style
+    from matplotlib.style.core import STYLE_EXTENSION
+    CAN_PLOT = True
+
+from viperleed.calc.lib.version import Version
+
+
+class HasNoMatplotlibError(Exception):
+    """No matplotlib installation was found."""
+
+    _default_msg = ('Cannot proceed without matplotlib installed. Run '
+                    'python -m pip install matplotlib, then try again')
+
+    def __init__(self, message=None):
+        super().__init__(message or self._default_msg)
+
+
+# ###########################  DECORATORS  ############################
+
+def log_without_matplotlib(logger, level='debug', msg=''):
+    """Emit a message to logger if matplotlib is not available, then return.
+
+    Parameters
+    ----------
+    logger : Logger
+        The logger that should emit the message.
+    level : str, optional
+        Which of the methods of `logger` to use. Default is 'debug'.
+    msg : str, optional
+        Extra information to be logged. Default is an empty string.
+
+    Returns
+    -------
+    decorator : callable
+        A decorator ready to be applied to any function. If
+        no matplotlib is found, the decorated function logs
+        the desired message, then returns None. Otherwise,
+        it returns the same as the decorated function.
+    """
+    log_emit = getattr(logger, level)
+    log_msg = 'Necessary modules for plotting not found.'
+    if msg:
+        log_msg += f' {msg}'
+
+    def _decorator(func):
+        @wraps(func)
+        def _wrapper(*args, **kwargs):
+            if not CAN_PLOT:
+                log_emit(log_msg)
+                return None
+            return func(*args, **kwargs)
+        return _wrapper
+    return _decorator
+
+
+def skip_without_matplotlib(func):
+    """Decorate func, and return early if matplotlib is not available."""
+    @wraps(func)
+    def _wrapper(*args, **kwargs):
+        if not CAN_PLOT:
+            return None
+        return func(*args, **kwargs)
+    return _wrapper
+
+
+def raise_without_matplotlib(func):
+    """Decorate func, and complain if matplotlib is not available."""
+    @wraps(func)
+    def _wrapper(*args, **kwargs):
+        if not CAN_PLOT:
+            raise HasNoMatplotlibError
+        return func(*args, **kwargs)
+    return _wrapper
+
+
+# ############################  FUNCTIONS  ############################
+
+@skip_without_matplotlib
+def prepare_matplotlib_for_calc():
+    """Prepare matplotlib for use in viperleed.calc."""
+    matplotlib.rcParams.update({'figure.max_open_warning': 0})
+    matplotlib.use('Agg')                                                       # TODO: check with Michele if this causes conflicts
+    use_calc_style()
+
+
+@skip_without_matplotlib
+def use_calc_style():
+    """Use viperleed.calc matplotlib style for plotting."""
+    if Version(mpl_version) >= '3.7':
+        mpl_style.use('viperleed.calc')
+        return
+    # In the early versions of matplotlib, dotted names cannot be
+    # used to locate styles. Use here a simplified version of the
+    # implementation of more recent matplotlib (v3.7.5)
+    path = importlib_resources.files('viperleed') / f'calc.{STYLE_EXTENSION}'
+
+    # Implementation of _rc_params_in_file differs slightly in older
+    # matplotlib versions. Hopefully it works anyway.
+    mpl_style.use(_rc_params_in_file(path))

--- a/src/viperleed/calc/lib/matplotlib_utils.py
+++ b/src/viperleed/calc/lib/matplotlib_utils.py
@@ -13,8 +13,9 @@ __license__ = 'GPLv+3'
 
 from functools import wraps
 import logging
+from pathlib import Path
 import sys
-from traceback import print_exc
+from traceback import format_exc
 
 if sys.version_info >= (3, 10):
     import importlib.resources as importlib_resources
@@ -120,7 +121,7 @@ def close_figures(pyplot, *figures):
         try:
             pyplot.close(figure)
         except Exception:                                                       # TODO: should catch correct ones, but let's have people tell us.
-            _LOGGER.warning(_log_msg, print_exc())
+            _LOGGER.warning(_log_msg, format_exc())
 
 
 @skip_without_matplotlib
@@ -140,7 +141,8 @@ def use_calc_style():
     # In the early versions of matplotlib, dotted names cannot be
     # used to locate styles. Use here a simplified version of the
     # implementation of more recent matplotlib (v3.7.5)
-    path = importlib_resources.files('viperleed') / f'calc.{STYLE_EXTENSION}'
+    vpr_path = Path(importlib_resources.files('viperleed'))
+    path = vpr_path / f'calc.{STYLE_EXTENSION}'
 
     # Implementation of _rc_params_in_file differs slightly in older
     # matplotlib versions. Hopefully it works anyway.

--- a/src/viperleed/calc/lib/matplotlib_utils.py
+++ b/src/viperleed/calc/lib/matplotlib_utils.py
@@ -12,7 +12,9 @@ __created__ = '2024-07-10'
 __license__ = 'GPLv+3'
 
 from functools import wraps
+import logging
 import sys
+from traceback import print_exc
 
 if sys.version_info >= (3, 10):
     import importlib.resources as importlib_resources
@@ -34,6 +36,9 @@ else:
     CAN_PLOT = True
 
 from viperleed.calc.lib.version import Version
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class HasNoMatplotlibError(Exception):
@@ -105,6 +110,18 @@ def raise_without_matplotlib(func):
 
 
 # ############################  FUNCTIONS  ############################
+
+@raise_without_matplotlib
+def close_figures(pyplot, *figures):
+    """Close pyplot figures safely."""
+    _log_msg = ('Failed to close figure. Please report this to the '
+                'ViPErLEED developers: %s')
+    for figure in figures:
+        try:
+            pyplot.close(figure)
+        except Exception:                                                       # TODO: should catch correct ones, but let's have people tell us.
+            _LOGGER.warning(_log_msg, print_exc())
+
 
 @skip_without_matplotlib
 def prepare_matplotlib_for_calc():

--- a/tests/calc/lib/test_matplotlib_utils.py
+++ b/tests/calc/lib/test_matplotlib_utils.py
@@ -1,0 +1,169 @@
+"""Tests for module matplotlib_utils of viperleed.calc.lib."""
+
+
+__authors__ = (
+    'Michele Riva (@michele-riva)',
+    )
+__copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
+__created__ = '2024-07-10'
+__license__ = 'GPLv+3'
+
+import logging
+import sys
+from unittest.mock import Mock
+
+import pytest
+from pytest_cases import fixture, parametrize
+
+# Import the module
+from viperleed.calc.lib import matplotlib_utils
+from viperleed.calc.lib.matplotlib_utils import _LOGGER
+from viperleed.calc.lib.matplotlib_utils import HasNoMatplotlibError
+from viperleed.calc.lib.matplotlib_utils import close_figures
+from viperleed.calc.lib.matplotlib_utils import log_without_matplotlib
+from viperleed.calc.lib.matplotlib_utils import prepare_matplotlib_for_calc
+from viperleed.calc.lib.matplotlib_utils import raise_without_matplotlib
+from viperleed.calc.lib.matplotlib_utils import skip_without_matplotlib
+from viperleed.calc.lib.matplotlib_utils import use_calc_style
+
+
+MOCK_RETURN = 'Function called'
+
+
+@fixture
+def mock_logger():
+    return Mock(logging.Logger)
+
+
+@fixture
+def mock_pyplot():
+    return Mock()
+
+
+@fixture(name='decorated', scope='session')
+def fixture_factory_decorated():
+    """Return a dummy function decorated by a given decorator."""
+    def mock_func():
+        return MOCK_RETURN
+
+    def _make(decorator):
+        return decorator(mock_func)
+
+    return _make
+
+
+@fixture(name='at_debug_level')
+def fixture_log_level():
+    """Yield the _LOGGER at DEBUG level, then clean it up."""
+    old_level = _LOGGER.level
+    _LOGGER.setLevel(logging.DEBUG)
+    try:
+        yield
+    finally:
+        _LOGGER.setLevel(old_level)
+
+
+class TestHasMatplotlibError:
+    """Collection of tests for HasNoMatplotlibError."""
+
+    def test_custom_msg(self):
+        """Check that a custom message is raised correctly."""
+        error_message = 'Custom error message'
+        error = HasNoMatplotlibError(error_message)
+        assert str(error) == error_message
+
+    def test_default_msg(self):
+        """Check that the default message is raised if none is given."""
+        error = HasNoMatplotlibError()
+        # pylint: disable-next=protected-access
+        assert str(error) == error._default_msg
+
+
+class TestCannotPlot:
+    """Collections of tests for missing matplotlib."""
+
+    @fixture(autouse=True)
+    def missing_matplotlib(self, monkeypatch):
+        monkeypatch.setattr(matplotlib_utils, 'CAN_PLOT', False)
+
+    @parametrize(decorator=(skip_without_matplotlib,
+                            log_without_matplotlib(_LOGGER)))
+    def test_returns_none(self, decorated, decorator):
+        """Check that decorating returns None without matplotlib."""
+        func = decorated(decorator)
+        assert func() is None
+
+    @parametrize(level=('debug', 'info', 'warning', 'error'))
+    # pylint: disable-next=unused-variable   # at_debug_level fixture
+    def test_log(self, level, caplog, decorated, at_debug_level):
+        """Check emits log message."""
+        func = decorated(log_without_matplotlib(_LOGGER, level=level))
+        func()
+        assert 'Necessary modules for plotting not found.' in caplog.text
+
+    def test_raises(self, decorated):
+        """Check that calling a raise-decorated function raises indeed."""
+        func = decorated(raise_without_matplotlib)
+        with pytest.raises(HasNoMatplotlibError):
+            func()
+
+
+class TestCanPlot:
+    """Collection of tests for when matplotlib is available."""
+
+    @fixture(autouse=True)
+    def with_matplotlib(self, monkeypatch):
+        monkeypatch.setattr(matplotlib_utils, 'CAN_PLOT', True)
+
+    @parametrize(decorator=(skip_without_matplotlib,
+                            log_without_matplotlib(_LOGGER),
+                            raise_without_matplotlib))
+    def test_returns_expected(self, decorated, decorator):
+        """Check that decorating returns None without matplotlib."""
+        func = decorated(decorator)
+        assert func() == MOCK_RETURN
+
+    @parametrize(level=('debug', 'info', 'warning', 'error'))
+    def test_does_not_log(self, level, decorated, mock_logger):
+        """Check that no logging messages are emitted."""
+        func = decorated(log_without_matplotlib(mock_logger, level=level))
+        func()
+        mock_logger.debug.assert_not_called()
+
+    def test_close_figures(self, mock_pyplot):
+        """Check that calling close_figures calls pyplot.close."""
+        figures = Mock(), Mock()
+        close_figures(mock_pyplot, *figures)
+        for fig in figures:
+            mock_pyplot.close.assert_any_call(fig)
+
+    def test_close_figures_exception_logs(self, mock_pyplot, caplog):
+        """Check that exceptions during close_figures are logged."""
+        _exc_text = 'Close failed'
+        mock_pyplot.close.side_effect = Exception(_exc_text)
+        close_figures(mock_pyplot, Mock())
+        print(caplog.text)
+        assert _exc_text in caplog.text
+
+    def test_prepare_matplotlib_for_calc(self, monkeypatch):
+        """Check that all the expected functions are called."""
+        mock_matplotlib = Mock()
+        monkeypatch.setattr(matplotlib_utils, 'matplotlib', mock_matplotlib)
+        monkeypatch.setattr(matplotlib_utils,
+                            'mpl_style',
+                            mock_matplotlib.style)
+
+        prepare_matplotlib_for_calc()
+        mock_matplotlib.rcParams.update.assert_called_once_with(
+            {'figure.max_open_warning': 0}
+            )
+        mock_matplotlib.use.assert_called_once_with('Agg')
+        mock_matplotlib.style.use.assert_called_once()
+
+    @parametrize(mpl_version=('3.6', '3.7'))
+    def test_use_calc_style(self, mpl_version, monkeypatch):
+        mock_mpl_style = Mock()
+        monkeypatch.setattr(matplotlib_utils, 'mpl_version', mpl_version)
+        monkeypatch.setattr(matplotlib_utils, 'mpl_style', mock_mpl_style)
+        use_calc_style()
+        mock_mpl_style.use.assert_called_once()


### PR DESCRIPTION
- Fixes an `OSError` in Python 3.7 on `matplotlib.style.use`: matplotlib <3.7 does not support dotted names.
- Other small refactoring and improvements, related to our use of matplotlib in calc
- tests with 100% coverage
- tests on py3.7 fail (phaseshifts, sections) due to #233 