### PR TITLE
fix: index error when detecting firmware folders

### DIFF
--- a/guilib/measure/dialogs/firmwareupgradedialog.py
+++ b/guilib/measure/dialogs/firmwareupgradedialog.py
@@ -384,7 +384,10 @@ class FirmwareUpgradeDialog(qtw.QDialog):
             with ZipFile(file, mode='r') as archive:
                 # !!! We are assuming here that the first folder in the
                 # .zip file matches the name of the firmware version.
-                folder_name, *_ = archive.namelist()[0].split('/')
+                try:
+                    folder_name, *_ = archive.namelist()[0].split('/')
+                except IndexError:
+                    continue
                 *_, version_str = folder_name.split('_')
                 try:
                     version = base.Version(version_str)


### PR DESCRIPTION
When looking for firmware folders we look through the internal folder structure in a zip file. This could have resulted in an index error for empty folders before this fix.