### PR TITLE
Add dataclass utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     'quicktions',
     'scipy',
     'scikit-learn',
+    'typing-extensions; python_version<"3.12"',
     'wrapt',
     ]
 keywords = [

--- a/src/viperleed/calc/classes/rparams/special/layer_cuts.py
+++ b/src/viperleed/calc/classes/rparams/special/layer_cuts.py
@@ -23,6 +23,7 @@ import re
 from typing import Any
 
 from viperleed.calc.lib.base import pairwise
+from viperleed.calc.lib.dataclass_utils import set_frozen_attr
 
 from .base import SpecialParameter
 
@@ -116,9 +117,9 @@ class LayerCutToken:
         if not self.is_auto_cut and (self.lower, self.upper) != (None, None):
             raise ValueError('Only dc/dz can have bounds')
         if isinstance(self.lower, Real):
-            object.__setattr__(self, 'lower', self.make_numeric(self.lower))
+            set_frozen_attr(self, 'lower', self.make_numeric(self.lower))
         if isinstance(self.upper, Real):
-            object.__setattr__(self, 'upper', self.make_numeric(self.upper))
+            set_frozen_attr(self, 'upper', self.make_numeric(self.upper))
         if self.is_auto_cut:
             self._check_valid_bound_type(self.lower, self.upper)
 

--- a/src/viperleed/calc/classes/rparams/special/layer_cuts.py
+++ b/src/viperleed/calc/classes/rparams/special/layer_cuts.py
@@ -15,7 +15,6 @@ __created__ = '2023-10-21'
 __license__ = 'GPLv3+'
 
 from collections.abc import Sequence
-from dataclasses import dataclass
 from enum import IntEnum, auto
 import itertools
 from numbers import Real
@@ -23,6 +22,7 @@ import re
 from typing import Any
 
 from viperleed.calc.lib.base import pairwise
+from viperleed.calc.lib.dataclass_utils import frozen
 from viperleed.calc.lib.dataclass_utils import set_frozen_attr
 
 from .base import SpecialParameter
@@ -50,7 +50,7 @@ class LayerCutTokenType(IntEnum):
 _AUTO_CUT_RE = re.compile(r'(?P<type>dz|dc)\((?P<cutoff>[\d.]+)\)')
 
 
-@dataclass(frozen=True)
+@frozen
 class LayerCutToken:
     """A single token of a LayerCuts object."""
 

--- a/src/viperleed/calc/classes/rparams/special/search_cull.py
+++ b/src/viperleed/calc/classes/rparams/special/search_cull.py
@@ -15,6 +15,8 @@ from dataclasses import InitVar, dataclass, field
 from enum import Enum  # Unfortunately StrEnum was introduced in py3.11
 from numbers import Real
 
+from viperleed.calc.lib.dataclass_utils import non_init_field
+
 from ..defaults import NO_VALUE
 from .base import SpecialParameter
 
@@ -65,9 +67,9 @@ class SearchCull(SpecialParameter, param='SEARCH_CULL'):
     """
 
     _value: InitVar[Real]
-    _type: SearchCullType = field(default=NO_VALUE, repr=False)
-    _int: int = field(init=False, default=NO_VALUE, repr=False)
-    _fraction: float = field(init=False, default= NO_VALUE, repr=False)
+    _type: SearchCullType = field(default=NO_VALUE)
+    _int: int = non_init_field(default=NO_VALUE)
+    _fraction: float = non_init_field(default= NO_VALUE)
 
     def __post_init__(self, _value):
         """Assign integer or fractional values for this SearchCull."""

--- a/src/viperleed/calc/files/parameters/utils.py
+++ b/src/viperleed/calc/files/parameters/utils.py
@@ -20,6 +20,8 @@ __license__ = 'GPLv3+'
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 
+from viperleed.calc.lib.dataclass_utils import set_frozen_attr
+
 
 # TODO: some of these classes are probably also useful for other
 # files, possibly with little modification. If they are, they
@@ -78,8 +80,7 @@ class NumericBounds:
             raise ValueError('out_of_range_event "modulo" needs both limits '
                              'to be acceptable.')
 
-        # Use object.__setattr__ for frozen data-class
-        object.__setattr__(self, '_msg_', self._make_message())
+        set_frozen_attr(self, '_msg_', self._make_message())
 
     @property
     def coerce(self):
@@ -206,24 +207,25 @@ class Assignment:
     def __post_init__(self):
         """Split out left- and right-hand sides into flags and values."""
         try:
-            object.__setattr__(self, 'parameter', self.parameter.strip())
+            value = self.parameter.strip()
         except AttributeError as exc:  # Not a string
             raise TypeError('parameter must be a string') from exc
-        if not self.parameter:
+        if value:
             raise ValueError('parameter must contain printable characters')
+        set_frozen_attr(self, 'parameter', value)
 
         flags = self._unpack_assignment_side(self.flags_str)
         values = self._unpack_assignment_side(self.values_str)
 
-        object.__setattr__(self, 'flags', flags)
-        object.__setattr__(self, 'values', values)
+        set_frozen_attr(self, 'flags', flags)
+        set_frozen_attr(self, 'values', values)
 
         # Make sure values_str and flags_str are actually strings:
         # we also accept Sequence of strings at __init__
         if not isinstance(self.values_str, str):
-            object.__setattr__(self, 'values_str', ' '.join(self.values_str))
+            set_frozen_attr(self, 'values_str', ' '.join(self.values_str))
         if not isinstance(self.flags_str, str):
-            object.__setattr__(self, 'flags_str', ' '.join(self.flags_str))
+            set_frozen_attr(self, 'flags_str', ' '.join(self.flags_str))
 
     @property
     def flag(self):

--- a/src/viperleed/calc/files/parameters/utils.py
+++ b/src/viperleed/calc/files/parameters/utils.py
@@ -211,7 +211,7 @@ class Assignment:
             value = self.parameter.strip()
         except AttributeError as exc:  # Not a string
             raise TypeError('parameter must be a string') from exc
-        if value:
+        if not value:
             raise ValueError('parameter must contain printable characters')
         set_frozen_attr(self, 'parameter', value)
 

--- a/src/viperleed/calc/files/parameters/utils.py
+++ b/src/viperleed/calc/files/parameters/utils.py
@@ -18,9 +18,9 @@ __created__ = '2023-10-16'
 __license__ = 'GPLv3+'
 
 from collections.abc import Sequence
-from dataclasses import field
 
 from viperleed.calc.lib.dataclass_utils import frozen
+from viperleed.calc.lib.dataclass_utils import non_init_field
 from viperleed.calc.lib.dataclass_utils import set_frozen_attr
 
 
@@ -52,7 +52,7 @@ class NumericBounds:
     range_: tuple = (None, None)
     accept_limits: tuple = (True, True)
     out_of_range_event: str = 'fail'
-    _msg_: str = field(init=False)
+    _msg_: str = non_init_field()
 
     def __post_init__(self):
         """Process assigned attributes.
@@ -202,8 +202,8 @@ class Assignment:
     values_str: str
     parameter: str
     flags_str: str = ''
-    flags: tuple = field(init=False)
-    values: tuple = field(init=False)
+    flags: tuple = non_init_field()
+    values: tuple = non_init_field()
 
     def __post_init__(self):
         """Split out left- and right-hand sides into flags and values."""

--- a/src/viperleed/calc/files/parameters/utils.py
+++ b/src/viperleed/calc/files/parameters/utils.py
@@ -18,8 +18,9 @@ __created__ = '2023-10-16'
 __license__ = 'GPLv3+'
 
 from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import field
 
+from viperleed.calc.lib.dataclass_utils import frozen
 from viperleed.calc.lib.dataclass_utils import set_frozen_attr
 
 
@@ -28,7 +29,7 @@ from viperleed.calc.lib.dataclass_utils import set_frozen_attr
 # could go higher up the hierarchy into a file.utils.py or similar
 
 
-@dataclass(frozen=True)
+@frozen
 class NumericBounds:
     """A container for bounds of numeric parameters.
 
@@ -173,7 +174,7 @@ POSITIVE_INT = NumericBounds(type_=int, range_=(1, None))
 POSITIVE_FLOAT = NumericBounds(type_=float, range_=(0, None))
 
 
-@dataclass(frozen=True)
+@frozen
 class Assignment:
     """Class to store the flags and values of a parameter.
 

--- a/src/viperleed/calc/from_ase.py
+++ b/src/viperleed/calc/from_ase.py
@@ -33,6 +33,7 @@ from viperleed.calc.files import parameters, poscar
 from viperleed.calc.files.beams import readOUTBEAMS
 from viperleed.calc.files.ivplot import plot_iv
 from viperleed.calc.lib.base import rotation_matrix
+from viperleed.calc.lib.dataclass_utils import set_frozen_attr
 from viperleed.calc.run import run_calc
 from viperleed.extensions.error_codes import check_ierr
 
@@ -120,9 +121,9 @@ class _ImmutableSlabTransform(SlabTransform):
 
     def __init__(self):
         """Initialize instance attributes."""
-        object.__setattr__(self, 'orthogonal_matrix', None)
-        object.__setattr__(self, 'uc_scaling', None)
-        object.__setattr__(self, 'cut_cell_c_fraction', 0.)
+        set_frozen_attr(self, 'orthogonal_matrix', None)
+        set_frozen_attr(self, 'uc_scaling', None)
+        set_frozen_attr(self, 'cut_cell_c_fraction', 0.)
 
     def __setattr__(self, name, value):
         """Raise FrozenInstanceError."""

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -1,0 +1,23 @@
+"""Module dataclasses_utils of viperleed.calc.lib.
+
+Collects useful functions that add up on top of the dataclasses
+stdlib module.
+"""
+
+__authors__ = (
+    'Michele Riva (@michele-riva)',
+    )
+__copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
+__created__ = '2024-07-25'
+__license__ = 'GPLv3+'
+
+from typing import Optional
+
+
+def is_optional_field(field, with_type=None):
+    """Return whether a datclasses.Field is optional."""
+    if with_type is None:
+        with_type = field.type
+    # The following trick works because Optional removes 'repeated'
+    # entries, so that Optional[Optional[t]] == Optional[t]
+    return field.type == Optional[with_type]

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -42,7 +42,26 @@ frozen = dataclass_transform(frozen_default=True)(
 
 
 def check_types(self, init_only=False):
-    """Raise TypeError if fields don't match their type hints."""
+    """Raise TypeError if fields don't match their type hints.
+
+    Parameters
+    ----------
+    init_only : bool, optional
+        Whether only the fields used for initialization should be
+        checked. Default is False, corresponding to checking all
+        fields.
+
+    Notes
+    -----
+    Only the type of the fields is checked: The types of the items of
+        collection fields are not checked.
+    InitVar and ClassVar attributes are also unchecked.
+
+    Raises
+    ------
+    TypeError
+        If any of the field types do not fit their type hints.
+    """
     for field in data_fields(self):
         if init_only and not field.init:
             continue

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -11,9 +11,12 @@ __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2024-07-25'
 __license__ = 'GPLv3+'
 
+import functools
+from dataclasses import dataclass
 from dataclasses import fields as data_fields
 from dataclasses import is_dataclass
 import typing
+import sys
 
 try:  # Import stuff that was made available since py3.8
     from typing import get_args as ty_get_args
@@ -22,6 +25,16 @@ except ImportError:
     from typing_extensions import get_origin as ty_get_origin
 else:
     from typing import get_origin as ty_get_origin
+
+if sys.version_info < (3, 12):  # No frozen_default keyword in py3.11
+    from typing_extensions import dataclass_transform
+else:
+    from typing import dataclass_transform
+
+
+frozen = dataclass_transform(frozen_default=True)(
+    functools.partial(dataclass, frozen=True)
+    )
 
 
 def check_types(self, init_only=False):

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -24,6 +24,21 @@ else:
     from typing import get_origin as ty_get_origin
 
 
+def check_types(self, init_only=False):
+    """Raise TypeError if fields don't match their type hints."""
+    for field in data_fields(self):
+        if init_only and not field.init:
+            continue
+        attr = field.name
+        value = getattr(self, attr)
+        actual_types = tuple(_find_type_origin(field.type))
+        if actual_types and not isinstance(value, actual_types):
+            raise TypeError(
+                    f'Expected type {field.type} for argument {attr!r} '
+                    f'but received type {type(value).__name__!r} instead'
+                    )
+
+
 def is_optional_field(field, with_type=None):
     """Return whether a datclasses.Field is optional."""
     if with_type is None:

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -208,6 +208,10 @@ _SpecialType = tuple({  # These types are not pubic API
 def _find_type_origin(type_hint):
     """Yield nested type origins from a `type_hint`."""
     # Adapted from https://stackoverflow.com/questions/50563546
+    if type_hint in (typing.Any, ...):
+        yield object  # Not quite accurate, but close enough
+        return
+
     if isinstance(type_hint, _SpecialType):
         # Special types, without extra parameters
         return

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -11,18 +11,18 @@ __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2024-07-25'
 __license__ = 'GPLv3+'
 
-from dataclasses import fields
+from dataclasses import fields as data_fields
 from dataclasses import is_dataclass
 from typing import Optional
 
 
-def is_optional_field(field_, with_type=None):
+def is_optional_field(field, with_type=None):
     """Return whether a datclasses.Field is optional."""
     if with_type is None:
-        with_type = field_.type
+        with_type = field.type
     # The following trick works because Optional removes 'repeated'
     # entries, so that Optional[Optional[t]] == Optional[t]
-    return field_.type == Optional[with_type]
+    return field.type == Optional[with_type]
 
 
 # TODO: this may be made stricter to ensure it is only used
@@ -61,6 +61,7 @@ def set_frozen_attr(self, attr_name, attr_value):
         getattr(self, attr_name)
     except AttributeError:
         # It may still be that the attribute is a init=False field.
-        if not any(f.name == attr_name for f in fields(self) if not f.init):
+        non_init = (f for f in data_fields(self) if not f.init)
+        if not any(f.name == attr_name for f in non_init):
             raise
     object.__setattr__(self, attr_name, attr_value)

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -173,7 +173,11 @@ def set_frozen_attr(self, attr_name, attr_value):
         non_init = (f for f in data_fields(self) if not f.init)
         if not any(f.name == attr_name for f in non_init):
             raise
-    object.__setattr__(self, attr_name, attr_value)
+    try:
+        # Try setattr first, in case it's not frozen and it was edited
+        setattr(self, attr_name, attr_value)
+    except FrozenInstanceError:
+        object.__setattr__(self, attr_name, attr_value)
 
 
 _SpecialType = tuple({  # These types are not pubic API

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -14,6 +14,40 @@ __license__ = 'GPLv3+'
 from typing import Optional
 
 
+# TODO: this may be made stricter to ensure it is only used
+# inside the source code of a dataclass and not from user code.
+# One can use sys._get_frame (CPython only) as suggested in
+# https://stackoverflow.com/questions/900392 or
+# https://stackoverflow.com/questions/2654113
+def set_frozen_attr(self, attr_name, attr_value):
+    """Set self.attr_name to attr_value even if self is frozen.
+
+    It is **VERY IMPORTANT** to realize that this function is a
+    workaround that makes a frozen dataclass not actually frozen.
+    It is thus critical that this function is used **only** in
+    a context where it makes sense to actually modify an attribute
+    of a dataclass that is supposed to be immutable. This usually
+    means that this function should be used ONLY INTERNALLY in the
+    implementation of a dataclass.
+
+    Parameters
+    ----------
+    self : dataclass
+        The dataclass whose attribute should be set.
+    attr_name : str
+        The name of the attribute to set.
+    attr_value : object
+        The value of the attribute.
+
+    Raises
+    ------
+    AttributeError
+        If self has no `attr_name` attribute.
+    """
+    getattr(self, attr_name)  # Raises AttributeError if not present
+    object.__setattr__(self, attr_name, attr_value)
+
+
 def is_optional_field(field, with_type=None):
     """Return whether a datclasses.Field is optional."""
     if with_type is None:

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -57,7 +57,7 @@ def check_types(self, init_only=False):
 
 
 def is_optional_field(field, with_type=None):
-    """Return whether a datclasses.Field is optional."""
+    """Return whether a dataclasses.Field is optional."""
     if with_type is None:
         with_type = field.type
     # The following trick works because Optional removes 'repeated'
@@ -138,7 +138,7 @@ def replace_values(instance, skip=(), **changes):
 # https://stackoverflow.com/questions/900392 or
 # https://stackoverflow.com/questions/2654113
 def set_frozen_attr(self, attr_name, attr_value):
-    """Set self.attr_name to attr_value even if self is frozen.
+    """Set `attr_name` to `attr_value`, even if `self` is frozen.
 
     It is **VERY IMPORTANT** to realize that this function is a
     workaround that makes a frozen dataclass not actually frozen.
@@ -160,7 +160,9 @@ def set_frozen_attr(self, attr_name, attr_value):
     Raises
     ------
     AttributeError
-        If self has no `attr_name` attribute.
+        If `self` has no `attr_name` attribute.
+    TypeError
+        If `self` is not a dataclass.
     """
     if not is_dataclass(self):
         raise TypeError('Cannot use set_frozen_attr on non-dataclass objects')

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -13,7 +13,7 @@ __license__ = 'GPLv3+'
 
 from dataclasses import fields as data_fields
 from dataclasses import is_dataclass
-from typing import Optional
+import typing
 
 
 def is_optional_field(field, with_type=None):
@@ -22,7 +22,7 @@ def is_optional_field(field, with_type=None):
         with_type = field.type
     # The following trick works because Optional removes 'repeated'
     # entries, so that Optional[Optional[t]] == Optional[t]
-    return field.type == Optional[with_type]
+    return field.type == typing.Optional[with_type]
 
 
 # TODO: this may be made stricter to ensure it is only used

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -48,10 +48,10 @@ def set_frozen_attr(self, attr_name, attr_value):
     object.__setattr__(self, attr_name, attr_value)
 
 
-def is_optional_field(field, with_type=None):
+def is_optional_field(field_, with_type=None):
     """Return whether a datclasses.Field is optional."""
     if with_type is None:
-        with_type = field.type
+        with_type = field_.type
     # The following trick works because Optional removes 'repeated'
     # entries, so that Optional[Optional[t]] == Optional[t]
-    return field.type == Optional[with_type]
+    return field_.type == Optional[with_type]

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -11,9 +11,18 @@ __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2024-07-25'
 __license__ = 'GPLv3+'
 
-from typing import Optional
 from dataclasses import fields
 from dataclasses import is_dataclass
+from typing import Optional
+
+
+def is_optional_field(field_, with_type=None):
+    """Return whether a datclasses.Field is optional."""
+    if with_type is None:
+        with_type = field_.type
+    # The following trick works because Optional removes 'repeated'
+    # entries, so that Optional[Optional[t]] == Optional[t]
+    return field_.type == Optional[with_type]
 
 
 # TODO: this may be made stricter to ensure it is only used
@@ -55,12 +64,3 @@ def set_frozen_attr(self, attr_name, attr_value):
         if not any(f.name == attr_name for f in fields(self) if not f.init):
             raise
     object.__setattr__(self, attr_name, attr_value)
-
-
-def is_optional_field(field_, with_type=None):
-    """Return whether a datclasses.Field is optional."""
-    if with_type is None:
-        with_type = field_.type
-    # The following trick works because Optional removes 'repeated'
-    # entries, so that Optional[Optional[t]] == Optional[t]
-    return field_.type == Optional[with_type]

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -12,6 +12,8 @@ __created__ = '2024-07-25'
 __license__ = 'GPLv3+'
 
 from typing import Optional
+from dataclasses import fields
+from dataclasses import is_dataclass
 
 
 # TODO: this may be made stricter to ensure it is only used
@@ -44,7 +46,14 @@ def set_frozen_attr(self, attr_name, attr_value):
     AttributeError
         If self has no `attr_name` attribute.
     """
-    getattr(self, attr_name)  # Raises AttributeError if not present
+    if not is_dataclass(self):
+        raise TypeError('Cannot use set_frozen_attr on non-dataclass objects')
+    try:
+        getattr(self, attr_name)
+    except AttributeError:
+        # It may still be that the attribute is a init=False field.
+        if not any(f.name == attr_name for f in fields(self) if not f.init):
+            raise
     object.__setattr__(self, attr_name, attr_value)
 
 

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -13,6 +13,7 @@ __license__ = 'GPLv3+'
 
 import functools
 from dataclasses import dataclass
+from dataclasses import field as data_field
 from dataclasses import fields as data_fields
 from dataclasses import is_dataclass
 import typing
@@ -59,6 +60,17 @@ def is_optional_field(field, with_type=None):
     # The following trick works because Optional removes 'repeated'
     # entries, so that Optional[Optional[t]] == Optional[t]
     return field.type == typing.Optional[with_type]
+
+
+def non_init_field(**kwargs):
+    """Return a dataclass field not used for initialization."""
+    try:
+        kwargs['default_factory']
+    except KeyError:  # Can't set a default if there's a factory
+        kwargs.setdefault('default', None)
+    kwargs['init'] = False
+    kwargs.setdefault('repr', False)
+    return data_field(**kwargs)
 
 
 # TODO: this may be made stricter to ensure it is only used

--- a/src/viperleed/calc/lib/dataclass_utils.py
+++ b/src/viperleed/calc/lib/dataclass_utils.py
@@ -1,4 +1,4 @@
-"""Module dataclasses_utils of viperleed.calc.lib.
+"""Module dataclass_utils of viperleed.calc.lib.
 
 Collects useful functions that add up on top of the dataclasses
 stdlib module.

--- a/tests/calc/lib/test_dataclass_utils.py
+++ b/tests/calc/lib/test_dataclass_utils.py
@@ -1,0 +1,381 @@
+"""Tests for dataclasses_utils module of viperleed/calc/lib."""
+
+__authors__ = (
+    'Michele Riva (@michele-riva)',
+    )
+__copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
+__created__ = '2024-08-04'
+__license__ = 'GPLv3+'
+
+from dataclasses import FrozenInstanceError
+from dataclasses import InitVar
+from dataclasses import dataclass
+from dataclasses import field as data_field
+from dataclasses import fields as data_fields
+from typing import Any
+from typing import ClassVar
+from typing import Dict
+from typing import List
+from typing import NoReturn
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Union
+
+import pytest
+from pytest_cases import parametrize
+
+from viperleed.calc.lib.dataclass_utils import _find_type_origin
+from viperleed.calc.lib.dataclass_utils import check_types
+from viperleed.calc.lib.dataclass_utils import frozen
+from viperleed.calc.lib.dataclass_utils import is_optional_field
+from viperleed.calc.lib.dataclass_utils import non_init_field
+from viperleed.calc.lib.dataclass_utils import replace_values
+from viperleed.calc.lib.dataclass_utils import set_frozen_attr
+
+from ...helpers import not_raises
+
+
+@frozen
+class SampleFrozenClass:
+    """A frozen dataclass."""
+
+    attr: int
+    optional_attr: Optional[int] = None
+    non_init: List[int] = non_init_field(
+        default_factory=lambda: [1, 'a', {}]
+        )
+
+
+@dataclass
+class SampleClass:
+    """A non-frozen dataclass."""
+
+    attr: int
+    optional_attr: Optional[int] = None
+    mutable_optional: List[Optional[int]] = data_field(default_factory=list)
+    non_init_with_default: int = non_init_field(default=10)
+    mutable_non_init: List[int] = non_init_field(default_factory=list)
+    any_attr: Any = 3
+    class_attr: ClassVar[int] = 42
+
+
+@dataclass
+class NestedClass:
+    """A dataclass to be used as field factory for another one."""
+
+    inner: int = 1
+
+
+@dataclass
+class ComplexClass:
+    """A dataclass with non-trivial type hints."""
+
+    attr: int
+    optional_attr: Optional[int] = None
+    list_non_init: List[Optional[int]] = non_init_field(default_factory=list)
+    dict_non_init: Dict[str, List[int]] = non_init_field(default_factory=dict)
+    init_only_var: InitVar[int] = 0
+    class_attr: ClassVar[int] = 42
+    dataclass_attr: NestedClass = non_init_field(default_factory=NestedClass)
+
+
+def test_frozen_decorator():
+    """Check correct behavior of the @frozen decorator."""
+    instance = SampleFrozenClass(attr=1, optional_attr=2)
+    with pytest.raises(FrozenInstanceError):
+        instance.attr = 3
+
+
+class TestFindTypeOrigin:
+    """Tests for the _find_type_origin function."""
+
+    _type_origins = {  # {hint: expected outcome}
+        Optional[int]: (int, type(None)),
+        List[int]: (list,),
+        Union[List[int], Dict[str, Tuple[int, float]]]: (list, dict),
+        Any: (object,),
+        ...: (object,),
+        ClassVar[int]: (int,),
+        NoReturn: (),  # a _SpecialForm
+        }
+    _type_origins_str = {str(h): e for h, e in _type_origins.items()}
+
+    @parametrize('hint,expect', _type_origins.items())
+    def test_from_hint(self, hint, expect):
+        """Check correct outcome of finding the origin of a type hint."""
+        origin = tuple(_find_type_origin(hint))
+        assert origin == expect
+
+    @parametrize('hint,expect', _type_origins_str.items())
+    @pytest.mark.xfail(reason='string annotations are still unsupported')
+    def test_from_string(self, hint, expect):
+        """Check correct outcome of finding the origin of a type hint."""
+        origin = tuple(_find_type_origin(hint))
+        assert origin == expect
+
+
+class TestCheckTypes:
+    """Collection of tests for the check_types function."""
+
+    def test_valid_type(self):
+        """Check that there are no complaints for a valid initialization."""
+        instance = SampleClass(attr=1)
+        with not_raises(TypeError):
+            check_types(instance)
+
+    _many_types = ({}, set(), tuple(), 3.5, 1+2j, object(), NestedClass())
+
+    @parametrize(value=_many_types)
+    def test_any_hint(self, value):
+        """Check that hinting with Any never complains."""
+        instance = SampleClass(attr=1, any_attr=value)
+        with not_raises(TypeError):
+            check_types(instance)
+
+    def test_invalid_type(self):
+        """Check complaints when an invalid type is given."""
+        instance = SampleClass(attr='string', optional_attr=2)
+        with pytest.raises(TypeError, match='attr'):
+            check_types(instance)
+
+    def test_dont_check_items(self):
+        """Check complaints for an invalid type of list items."""
+        instance = SampleClass(attr=1, mutable_optional=[None, 'string'])
+        with not_raises(TypeError):  # We don't check items
+            check_types(instance)
+
+    def test_dont_check_initvar(self):
+        """Check complaints for an invalid type of list items."""
+        instance = ComplexClass(attr=1, init_only_var='something wrong')
+        with not_raises(TypeError):
+            check_types(instance)
+
+    def test_init_only(self):
+        """Check no complaints if only types of init fields are verified."""
+        instance = SampleClass(1)
+        instance.non_init_with_default = []  # should be int
+        with pytest.raises(TypeError):
+            check_types(instance)
+        with not_raises(TypeError):
+            check_types(instance, init_only=True)
+
+
+def test_is_optional_field():
+    """Check correctness of the result of is_optional_field."""
+    fields = data_fields(SampleClass)
+    assert not is_optional_field(fields[0])  # attr
+    assert is_optional_field(fields[1])      # optional_attr
+
+
+class TestNonInitField:
+    """Tests for the non_init_field function."""
+
+    def test_defaul_value(self):
+        """Check the value of a non-initialization field with default."""
+        instance = SampleClass(attr=5)
+        # pylint: disable=magic-value-comparison  # OK for hard-coded
+        assert instance.attr == 5
+        assert instance.non_init_with_default == 10
+
+    def test_repr_false(self):
+        """Check that a non-initialization field does not show in repr."""
+        instance = SampleClass(attr=5)
+        # pylint: disable-next=magic-value-comparison  # OK for attr
+        assert 'non_init_with_default' not in str(instance)
+
+    def test_repr_true(self):
+        """Check that a non-initialization field shows in repr if specified."""
+        @dataclass
+        class _TestClass:
+            non_init: int = non_init_field(default=10, repr=True)
+
+        instance = _TestClass()
+        # pylint: disable-next=magic-value-comparison  # OK for attr
+        assert 'non_init' in repr(instance)
+
+
+class TestReplaceValues:
+    """Tests for the replace_values function."""
+
+    @dataclass
+    class ReplaceInfo:  # pylint: disable=too-many-instance-attributes
+        """Information about replacements."""
+
+        cls_to_replace: ...
+        init_args: Dict[str, Any]    # How to initialize cls_to_replace
+        equal: Tuple[str]        # Attributes that should compare equal
+        not_identical: Set[str]  # Equal attributes, but not "is"
+        identical: List[str]     # Attributes that compare with "is"
+        new_attr: str = None     # The attribute to be replaced
+        new_value: Any = None    # The new value of new_attr
+        replaced: Dict[str, Any] = non_init_field(repr=True,
+                                                  default_factory=dict)
+
+        def __post_init__(self):
+            """Make replaced."""
+            if self.new_attr is not None:
+                self.replaced[self.new_attr] = self.new_value
+
+    @staticmethod
+    def _check_instances(new_instance, old_instance):
+        """Test correct production of a replaced instance."""
+        assert new_instance is not old_instance
+        assert new_instance != old_instance
+
+    @staticmethod
+    def _check_identical_attrs(new_instance, old_instance, info):
+        """Check that all identical attributes are really identical."""
+        for identical_attr in info.identical:
+            old_ = getattr(old_instance, identical_attr)
+            assert getattr(new_instance, identical_attr) is old_
+
+    @staticmethod
+    def _check_equal_attrs(new_instance, old_instance, info):
+        """Check that attributes are equal, and sometimes not identical."""
+        for equal_attr in info.equal:
+            old_ = getattr(old_instance, equal_attr)
+            if equal_attr in info.not_identical:
+                assert getattr(new_instance, equal_attr) is not old_
+            else:
+                assert getattr(new_instance, equal_attr) is old_
+            assert getattr(new_instance, equal_attr) == old_
+
+    @staticmethod
+    def _prepare_replaced(info):
+        """Return an instance of cls with init_args, and a replaced one."""
+        init_args = info.init_args
+        instance = info.cls_to_replace(**init_args)
+        for arg, value in init_args.items():
+            assert getattr(instance, arg) is value
+        new_instance = replace_values(instance, **info.replaced)
+        return instance, new_instance
+
+    def _test_base(self, info):
+        """Make an instance of class, its replaced version, and check them."""
+        info.identical.remove(info.new_attr)
+        instance, new_instance = self._prepare_replaced(info)
+        self._check_instances(new_instance, instance)
+        self._check_identical_attrs(new_instance, instance, info)
+        self._check_equal_attrs(new_instance, instance, info)
+
+        new_attr = info.new_attr
+        assert getattr(new_instance, new_attr) != getattr(instance, new_attr)
+
+    _simple_repl = {
+        'attr': 15,
+        'optional_attr': 'replaced',
+        'any_attr': object(),
+        }
+
+    @parametrize('new_attr,new_value', _simple_repl.items(), ids=_simple_repl)
+    def test_simple_replace(self, new_attr, new_value):
+        """Check replacements on a simple class."""
+        info = self.ReplaceInfo(
+            cls_to_replace=SampleClass,
+            init_args={
+                'attr': object(),
+                'optional_attr': object(),
+                'mutable_optional': [1, 2, 3]
+                },
+            equal=('mutable_optional', 'mutable_non_init'),
+            not_identical={'mutable_non_init',},
+            identical=['attr', 'optional_attr', 'non_init_with_default',
+                       'any_attr', 'class_attr'],
+            new_attr=new_attr,
+            new_value=new_value,
+            )
+        self._test_base(info)
+
+    _frozen_repl = {
+        'attr': 15,
+        'optional_attr': 'replaced',
+        }
+
+    @parametrize('new_attr,new_value', _frozen_repl.items(), ids=_frozen_repl)
+    def test_replace_frozen(self, new_attr, new_value):
+        """Check correct replacement of attributes from a frozen class."""
+        info = self.ReplaceInfo(
+            cls_to_replace=SampleFrozenClass,
+            init_args={'attr': object(),
+                       'optional_attr': object()},
+            equal=('non_init',),
+            not_identical={'non_init',},
+            identical=['attr', 'optional_attr'],
+            new_attr=new_attr,
+            new_value=new_value,
+            )
+        self._test_base(info)
+
+    def test_replace_skip(self):
+        """Check correct skipping of specified non-init fields."""
+        info = self.ReplaceInfo(
+            cls_to_replace=ComplexClass,
+            init_args={
+                'attr': object(),
+                'optional_attr': object(),
+                'init_only_var': object(),
+                },
+            equal=('list_non_init',
+                   # 'dict_non_init',  # This is the one we skip
+                   'dataclass_attr'),
+            not_identical=('list_non_init',
+                           'dataclass_attr'),
+            identical=('attr',
+                       # 'optional_attr',  # This is the one we replace
+                       'init_only_var',
+                       'class_attr'),
+            new_attr='optional_attr',
+            )
+        replaced = {'optional_attr': NestedClass(),
+                    'init_only_var': info.init_args['init_only_var']}
+        skip = 'dict_non_init'
+        new_attr = info.new_attr
+
+        instance = ComplexClass(**info.init_args)
+        instance.dict_non_init = {i: i for i in range(5)}
+        new_instance = replace_values(instance, skip=skip, **replaced)
+        self._check_instances(new_instance, instance)
+        self._check_identical_attrs(new_instance, instance, info)
+        self._check_equal_attrs(new_instance, instance, info)
+        assert getattr(new_instance, new_attr) != getattr(instance, new_attr)
+        assert getattr(new_instance, skip) != getattr(instance, skip)
+
+
+class TestSetFrozenAttr:
+    """Tests for the set_frozen_attr function."""
+
+    def test_frozen(self):
+        """Check correct setting of an attribute of a frozen dataclass."""
+        instance = SampleFrozenClass(attr=1)
+        set_frozen_attr(instance, 'attr', 10)
+        # pylint: disable-next=magic-value-comparison  # OK for attr
+        assert instance.attr == 10
+
+    def test_not_frozen(self):
+        """Check that setting a non-frozen attr works as expected."""
+        @dataclass
+        class _TestClass:
+            attr : ...
+            dependent_attr : ... = non_init_field()
+
+            def __setattr__(self, attr, value):
+                super().__setattr__(attr, value)
+                super().__setattr__('dependent_attr', value)
+
+        value = object()
+        instance = _TestClass(1)
+        set_frozen_attr(instance, 'attr', value)
+        assert instance.attr is value
+        assert instance.dependent_attr is value
+
+    def test_raises_not_dataclass(self):
+        """Check complaints when using set_frozen_attr on a non-dataclass."""
+        with pytest.raises(TypeError):
+            set_frozen_attr('not a dataclass', 'attr', 'value')
+
+    def test_raises_attribute_error(self):
+        """Check complaints when trying to set a non-existing attribute."""
+        instance = SampleFrozenClass(attr=1)
+        with pytest.raises(AttributeError):
+            set_frozen_attr(instance, 'does_not_exist', 3)

--- a/tests/calc/lib/test_time_utils.py
+++ b/tests/calc/lib/test_time_utils.py
@@ -8,7 +8,6 @@ __created__ = '2024-07-26'
 __license__ = 'GPLv3+'
 
 from collections import namedtuple
-from dataclasses import dataclass
 import datetime
 import sys
 import time
@@ -17,6 +16,7 @@ import pytest
 from pytest_cases import fixture
 from pytest_cases import parametrize
 
+from viperleed.calc.lib.dataclass_utils import frozen
 from viperleed.calc.lib.time_utils import DateTimeFormat
 from viperleed.calc.lib.time_utils import ExecutionTimer
 from viperleed.calc.lib.time_utils import ExpiringOnCountTimer
@@ -68,7 +68,7 @@ class MockTime:
     strftime = time.strftime
 
 
-@dataclass(order=True, frozen=True)
+@frozen(order=True)
 class MockCountable:
     """Come object that can be counted."""
 

--- a/tests/calc/testinfo.py
+++ b/tests/calc/testinfo.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Mapping, Set, Tuple
 import numpy as np
 
 from viperleed.calc.classes.rparams import LayerCuts
+from viperleed.calc.lib.dataclass_utils import non_init_field
 
 from ..helpers import InfoBase
 
@@ -85,7 +86,7 @@ class POSCARInfo(InfoBase):
     """Container for information about POSCAR files."""
     name: str = ''
     n_atoms: int = None
-    n_atoms_by_elem: dict = field(init=False, default_factory=dict)
+    n_atoms_by_elem: dict = non_init_field(default_factory=dict, repr=True)
     n_cells: int = 1  # How many 2D cells are in the POSCAR?
 
     def __post_init__(self):


### PR DESCRIPTION
Adds a new `calc.lib` module that collects various bits of code useful for handling `dataclasses`.

It also adds a **new dependency**: `typing-extensions`, a backport of new `typing` features down to Python 3.7

Tests for 100% coverage.
All tests passing.