### PR TITLE
fix: handle non-measuring controllers

### DIFF
--- a/guilib/measure/classes/datapoints.py
+++ b/guilib/measure/classes/datapoints.py
@@ -837,7 +837,9 @@ class DataPoints(qtc.QObject, MutableSequence, metaclass=QMetaABC):
                     if quantity in _EXCEPTIONAL:
                         # images and energies, already processed
                         continue
-                    for measurement in ctrl_dict.values():
+                    for ctrl, measurement in ctrl_dict.items():
+                        if not ctrl.measures():
+                            continue
                         extra_length = max_length - len(measurement)
                         data.append(measurement + [NAN]*extra_length)
                 for line in zip(*data):
@@ -1022,8 +1024,8 @@ class DataPoints(qtc.QObject, MutableSequence, metaclass=QMetaABC):
             if quantity in _EXCEPTIONAL:
                 # cameras and energy, already processed
                 continue
-            for controller in controllers:
-                header.append(
-                    f"{quantity.label}({controller.name})"
-                    )
+            for ctrl in controllers:
+                if not ctrl.measures():
+                    continue
+                header.append(f"{quantity.label}({ctrl.name})")
         return header

--- a/guilib/measure/measurement/abc.py
+++ b/guilib/measure/measurement/abc.py
@@ -1275,7 +1275,8 @@ class MeasurementABC(qtc.QObject, metaclass=base.QMetaABC):                     
         """
         controller = self.sender()
         self.data_points.add_data(data, controller)
-        self._missing_data[controller] -= 1
+        if controller.measures():
+            self._missing_data[controller] -= 1
         self._ready_for_next_measurement()
 
     @qtc.pyqtSlot(tuple)


### PR DESCRIPTION
Since non-measuring controllers would not be added to the _missing_data dictionary, decreasing their missing data count would lead to a KeyError before this fix.