### PR TITLE
32 bit tisgrabber fix

### DIFF
--- a/guilib/measure/camera/drivers/imagingsource/tisgrabber.py
+++ b/guilib/measure/camera/drivers/imagingsource/tisgrabber.py
@@ -253,7 +253,7 @@ class WindowsCamera:
         _dll = windll.LoadLibrary(str(dll_path / "tisgrabber_x64.dll"))
     else:
         windll.LoadLibrary(str(dll_path / "TIS_UDSHL11.dll"))
-        _dll = windll.LoadLibrary("tisgrabber.dll")
+        _dll = windll.LoadLibrary(str(dll_path / "tisgrabber.dll"))
 
     __initalized = False
 


### PR DESCRIPTION
Windows will now load the tisgrabber.dll file correctly for 32 bit python versions.