### PR TITLE
Document Intel oneAPI maximum version for ifort

### DIFF
--- a/doc/content/calc/install_tensor_leed.rst
+++ b/doc/content/calc/install_tensor_leed.rst
@@ -194,6 +194,21 @@ This section provides a guide on how to install the Intel Fortran compiler
 :term:`mpiifort`. All the necessary components are packaged as part of the
 |oneAPI| toolkits.
 
+.. _ifort_deprecation:
+.. warning::
+    The :program:`ifort` compiler (named "Fortran Compiler Classic") was
+    `deprecated by Intel <https://community.intel.com/t5/Blogs/Tech-Innovation/Tools/Deprecation-of-The-Intel-Fortran-Compiler-Classic-ifort/post/1541699>`__
+    in 2023, and has been replaced with the new LLVM-based :program:`ifx`
+    compiler. :program:`ifort` is no longer distributed with |oneAPI|
+    starting from version 2025.0. The most recent version that ships
+    :program:`ifort` is therefore 2024.2. |calc| currently **does not**
+    **support** :program:`ifx`. Be sure to use a version
+    :math:`\leq` 2024.2 when installing |oneAPI|.
+    If you cannot obtain an old-enough version that contains :program:`ifort`,
+    you may `ask Intel <https://community.intel.com/t5/oneAPI-Registration-Download/bd-p/registration-download-licensing-instal>`__
+    to provide you with a direct-download link. You can also contact us
+    on `GitHub <https://github.com/viperleed/viperleed/issues>`__.
+
 ViPErLEED requires the |oneAPI| Base Toolkit and the |oneAPI| HPC Toolkit.
 
 .. note::
@@ -232,8 +247,13 @@ The full documentation of the |oneAPI| is available from the
 
     .. code-block:: bash
 
-        sudo apt install intel-basekit -y
-        sudo apt install intel-hpckit -y
+        sudo apt install intel-basekit-<version> -y
+        sudo apt install intel-hpckit-<version> -y
+
+    .. warning::
+        Be sure to pick a ``<version>`` of |oneAPI| (e.g., replace
+        ``<version>`` above with ``2024.2``) that includes the :program:`ifort`
+        compiler. See also the :ref:`warning <ifort_deprecation>` above.
 
     Once installation completes, we need to configure the system and add the
     compilers to our system path. First, we need to make sure the required
@@ -270,7 +290,7 @@ The full documentation of the |oneAPI| is available from the
 
   .. tab-item:: macOS
 
-    .. warning::
+    .. note::
         Newer Macs using "Apple Silicon" ARM-based chips are incompatible
         with the Intel compilers (since they don't use Intel chips).
         Use :ref:`install_gcc` instead.
@@ -280,6 +300,10 @@ The full documentation of the |oneAPI| is available from the
     to install the |oneAPI| toolkits under macOS. As for
     :ref:`Linux<ifort_linux>`, you will need to install the |oneAPI| Base
     Toolkit and the |oneAPI| HPC Toolkit.
+
+    .. warning::
+        Be sure to pick a version of |oneAPI| that includes the :program:`ifort`
+        compiler. See also the :ref:`warning <ifort_deprecation>` above.
 
   .. tab-item:: Windows Subsystem for Linux
 
@@ -310,6 +334,10 @@ The full documentation of the |oneAPI| is available from the
     `guide <https://www.intel.com/content/www/us/en/develop/documentation/installation-guide-for-intel-oneapi-toolkits-windows/top.html>`__
     to install the |oneAPI| toolkits under Windows. As for Linux, you will
     need to install the |oneAPI| Base Toolkit and the |oneAPI| HPC Toolkit.
+
+    .. warning::
+        Be sure to pick a version of |oneAPI| that includes the :program:`ifort`
+        compiler. See also the :ref:`warning <ifort_deprecation>` above.
 
     The |oneAPI| toolkits require specific environment variables to be set
     before compilers can be used. The toolkits come with dedicated ``.bat``

--- a/tests/_test_data/parameters/PARAMETERS_fortran_comp
+++ b/tests/_test_data/parameters/PARAMETERS_fortran_comp
@@ -4,6 +4,10 @@ RUN = 0
 LOG_DEBUG = True
 THEO_ENERGIES =   50 350 3
 
+! Test that FORTRAN_COMP works without quotes
+FORTRAN_COMP = gfortran
+FORTRAN_COMP post = -llapack -lpthread -lblas
+
 
 ! ####### PARAMETERS FOR INTERPRETING THE POSCAR #######
 

--- a/tests/calc/files/parameters/case_parameters.py
+++ b/tests/calc/files/parameters/case_parameters.py
@@ -7,6 +7,7 @@ __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2023-09-07'
 __license__ = 'GPLv3+'
 
+from copy import deepcopy
 import numpy as np
 from pytest_cases import case, parametrize
 
@@ -68,13 +69,16 @@ for key in ('stop', 'no_stop', 'left empty'):
 _READ['missing_equals'].update(**_READ['Ag'])
 del _READ['missing_equals']['SUPERLATTICE']
 
-# FORTRAN_COMP added only for the 'Ag'
-_READ['Ag']['FORTRAN_COMP'] = ['gfortran', '-llapack -lpthread -lblas']
+# FORTRAN_COMP added on a copy of the Ag(100) file
+_READ['fortran comp'] = deepcopy(_READ['Ag'])
+_READ['fortran comp']['FORTRAN_COMP'] = ['gfortran',
+                                         '-llapack -lpthread -lblas']
 
 _PATHS = {
     'Ag': 'Ag(100)/initialization/PARAMETERS',
     'Ir': 'parameters/PARAMETERS_Ir(100)-(2x1)-O',
     'empty': 'parameters/PARAMETERS_empty',
+    'fortran comp': 'parameters/PARAMETERS_fortran_comp',
     'stop': 'parameters/PARAMETERS_stop',
     'no_stop': 'parameters/PARAMETERS_stop_false',
     'missing_equals': 'parameters/PARAMETERS_missing_equals',


### PR DESCRIPTION
This PR is a temporary fix for #189 until we support the `ifx` Intel compiler that has replaced `ifort`. The latter is no longer shipped starting with version 2025.0 that just came out.