### PR TITLE
Check Mpifort version

### DIFF
--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -396,7 +396,6 @@ class Rparams:
             f'{source_tree}.'
             )
 
-
     def updateDerivedParams(self):
         """
         Checks which derivative parameters (which cannot be calculated at
@@ -419,7 +418,6 @@ class Rparams:
             tl_source = self.get_tenserleed_directory()
             self.TL_VERSION = tl_source.version
             _LOGGER.debug(f'Detected TensErLEED version {str(self.TL_VERSION)}')
-
 
         # SEARCH_CONVERGENCE:
         if self.searchConvInit['gaussian'] is None:
@@ -695,22 +693,24 @@ class Rparams:
         elif found == 'mpifort':
             # check for the mpifort version
             mpifort_version = None
-            try:
+            mpifort_call = "mpifort -Ofast"
+            try:  # Add version-dependent CLI args
                 mpifort_version = fortran_utils.get_mpifort_version()
-            except fortran_utils.CouldNotDetermineMpifortVersionError:
+            except fortran_utils.FortranCompilerError:
                 _LOGGER.warning(
-                    'mpifort version could not be determined automatically. '
-                    'mpifort versions <= 10.0 may need the '
-                    '"-fallow-argument-mismatch flag" or "-std=legacy" flag to '
-                    'compile the TenseErLEED structure search code. '
-                    'If an error occurs, please check the mpifort version and '
-                    'adapt the FORTRAN_COMP parameter as required.'
+                    "mpifort version could not be determined automatically. "
+                    "mpifort versions >= 10.0 may need the "
+                    '"-fallow-argument-mismatch" or "-std=legacy" flags to '
+                    "compile the TenseErLEED structure-search code. "
+                    "If an error occurs, please check the mpifort version and "
+                    "adapt the FORTRAN_COMP parameter as required."
                 )
-            mpifort_call = 'mpifort -Ofast'
-            if mpifort_version is not None and mpifort_version > Version('9.0'):
-                mpifort_call += ' -fallow-argument-mismatch'
-
-            self.FORTRAN_COMP_MPI = [mpifort_call, '']
+            else:
+                mpifort_call += (
+                    "" if mpifort_version < "10.0"
+                    else " -fallow-argument-mismatch"
+                )
+            self.FORTRAN_COMP_MPI = [mpifort_call, ""]
             _LOGGER.debug('Using fortran compiler: mpifort')
 
     def renormalizeDomainParams(self, config):

--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -692,7 +692,6 @@ class Rparams:
             _LOGGER.debug('Using fortran compiler: mpiifort')
         elif found == 'mpifort':
             # check for the mpifort version
-            mpifort_version = None
             mpifort_call = "mpifort -Ofast"
             try:  # Add version-dependent CLI args
                 mpifort_version = fortran_utils.get_mpifort_version()

--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -703,12 +703,11 @@ class Rparams:
                     'compile the TenseErLEED structure-search code. '
                     'If an error occurs, please check the mpifort version and '
                     'adapt the FORTRAN_COMP parameter as required.'
-                )
+                    )
             else:
-                mpifort_call += (
-                    "" if mpifort_version < '10.0'
-                    else " -fallow-argument-mismatch"
-                )
+                mpifort_call += ('' if mpifort_version < '10.0'
+                                 else ' -fallow-argument-mismatch'
+                                )
             self.FORTRAN_COMP_MPI = [mpifort_call, '']
             _LOGGER.debug('Using fortran compiler: mpifort')
 

--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -706,8 +706,7 @@ class Rparams:
                     )
             else:
                 mpifort_call += ('' if mpifort_version < '10.0'
-                                 else ' -fallow-argument-mismatch'
-                                )
+                                 else ' -fallow-argument-mismatch')
             self.FORTRAN_COMP_MPI = [mpifort_call, '']
             _LOGGER.debug('Using fortran compiler: mpifort')
 

--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -29,6 +29,7 @@ import numpy as np
 from viperleed.calc.classes.searchpar import SearchPar
 from viperleed.calc.files import beams as iobeams
 from viperleed.calc.files.iodeltas import checkDelta
+from viperleed.calc.files.tenserleed import get_tenserleed_sources
 from viperleed.calc.lib import leedbase
 from viperleed.calc.lib.base import available_cpu_count
 from viperleed.calc.lib.checksums import KNOWN_TL_VERSIONS
@@ -40,7 +41,6 @@ from viperleed.calc.lib.matplotlib_utils import use_calc_style
 from viperleed.calc.lib.string_utils import parent_name
 from viperleed.calc.lib.time_utils import ExecutionTimer
 from viperleed.calc.lib.version import Version
-from viperleed.calc.files.tenserleed import get_tenserleed_sources
 from viperleed.calc.sections.calc_section import EXPBEAMS_NAMES
 
 from .defaults import DEFAULTS, NO_VALUE, TENSERLEED_FOLDER_NAME

--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -697,7 +697,7 @@ class Rparams:
             mpifort_version = None
             try:
                 mpifort_version = fortran_utils.get_mpifort_version()
-            except fortran_utils.CouldNotDeterminMpifortVersionError:
+            except fortran_utils.CouldNotDetermineMpifortVersionError:
                 _LOGGER.warning(
                     'mpifort version could not be determined automatically. '
                     'mpifort versions <= 10.0 may need the '

--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -692,24 +692,24 @@ class Rparams:
             _LOGGER.debug('Using fortran compiler: mpiifort')
         elif found == 'mpifort':
             # check for the mpifort version
-            mpifort_call = "mpifort -Ofast"
+            mpifort_call = 'mpifort -Ofast'
             try:  # Add version-dependent CLI args
                 mpifort_version = fortran_utils.get_mpifort_version()
             except fortran_utils.FortranCompilerError:
                 _LOGGER.warning(
-                    "mpifort version could not be determined automatically. "
-                    "mpifort versions >= 10.0 may need the "
+                    'mpifort version could not be determined automatically. '
+                    'mpifort versions >= 10.0 may need the '
                     '"-fallow-argument-mismatch" or "-std=legacy" flags to '
-                    "compile the TenseErLEED structure-search code. "
-                    "If an error occurs, please check the mpifort version and "
-                    "adapt the FORTRAN_COMP parameter as required."
+                    'compile the TenseErLEED structure-search code. '
+                    'If an error occurs, please check the mpifort version and '
+                    'adapt the FORTRAN_COMP parameter as required.'
                 )
             else:
                 mpifort_call += (
-                    "" if mpifort_version < "10.0"
+                    "" if mpifort_version < '10.0'
                     else " -fallow-argument-mismatch"
                 )
-            self.FORTRAN_COMP_MPI = [mpifort_call, ""]
+            self.FORTRAN_COMP_MPI = [mpifort_call, '']
             _LOGGER.debug('Using fortran compiler: mpifort')
 
     def renormalizeDomainParams(self, config):

--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -34,6 +34,8 @@ from viperleed.calc.lib import leedbase
 from viperleed.calc.lib.base import available_cpu_count
 from viperleed.calc.lib.checksums import KNOWN_TL_VERSIONS
 from viperleed.calc.lib.checksums import UnknownTensErLEEDVersionError
+from viperleed.calc.lib.fortran_utils import CouldNotDeterminMpifortVersionError
+from viperleed.calc.lib.fortran_utils import get_mpifort_version
 from viperleed.calc.lib.matplotlib_utils import CAN_PLOT
 from viperleed.calc.lib.matplotlib_utils import close_figures
 from viperleed.calc.lib.matplotlib_utils import skip_without_matplotlib

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -19,10 +19,13 @@ _FORTRAN_LINE_LENGTH = 72  # FORTRAN line-length limit
 _F77_CONTINUATION_POS = 6  # Column of the continuation character
 
 class MpifortNotFoundError(Exception):
+
     """Raised when the mpifort compiler is not found."""
+
 
 class CouldNotDeterminMpifortVersionError(Exception):
     """Raised when the mpifort version could not be determined."""
+
 
 def wrap_fortran_line(string):
     """Wrap a FORTRAN string into continuation lines with ampersands."""

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -52,14 +52,14 @@ def get_mpifort_version():
     try:
         subprocess.run(check_for_mpifort_call, shell=True, check=True)
     except subprocess.CalledProcessError:
-        raise GFortranNotFoundError
+        raise MpifortNotFoundError
 
     # get version number
     try:
         version_nr_str = subprocess.run(version_nr_call, shell=True, check=True,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except subprocess.CalledProcessError:
-        raise CouldNotDeterminGFortranVersionError
+        raise CouldNotDeterminMpifortVersionError
     mpifort_version = Version(version_nr_str.stdout.decode().strip())
 
     return mpifort_version

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -4,9 +4,10 @@ Collects functionality useful for handling FORTRAN code.
 """
 
 __authors__ = (
-    'Florian Kraushofer (@fkraushofer)',
-    'Michele Riva (@michele-riva)',
-    )
+    "Florian Kraushofer (@fkraushofer)",
+    "Alexander M. Imre (@amimre)",
+    "Michele Riva (@michele-riva)",
+)
 __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2024-08-26'
 __license__ = 'GPLv3+'

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -4,10 +4,10 @@ Collects functionality useful for handling FORTRAN code.
 """
 
 __authors__ = (
-    "Florian Kraushofer (@fkraushofer)",
-    "Alexander M. Imre (@amimre)",
-    "Michele Riva (@michele-riva)",
-)
+    'Florian Kraushofer (@fkraushofer)',
+    'Alexander M. Imre (@amimre)',
+    'Michele Riva (@michele-riva)',
+    )
 __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2024-08-26'
 __license__ = 'GPLv3+'
@@ -27,41 +27,40 @@ class FortranCompilerError(Exception):
 
 
 class CompilerNotFoundError(FortranCompilerError):
-    """Raised when the Fortran compiler is not found."""
+    """Raised when a Fortran compiler is not found."""
 
 
 class NoCompilerVersionFoundError(FortranCompilerError):
-    """Raised when the Fortran version could not be determined."""
+    """The version of a Fortran compiler could not be determined."""
 
 
 def get_mpifort_version():
-    """Check the version of the mpifort compiler."""
-    version_nr_call = ["mpifort", "--version"]
-    # check if mpifort is installed
-    if not shutil.which("mpifort"):
+    """Return the version of the mpifort compiler."""
+    # Check if mpifort is installed
+    if not shutil.which('mpifort'):
         raise CompilerNotFoundError
 
-    # get version number
+    # Get version number
+    version_nr_call = 'mpifort', '--version'
     try:
-        result = subprocess.run(
-            version_nr_call, shell=False, check=True, capture_output=True
-        )
-    except subprocess.CalledProcessError as err:
-        msg = str(err)
-        if err.stdout:
-            msg += f"\noutput:{err.stdout.decode()}"
-        if err.stderr:
-            msg += f"\nerrors:\n{err.stderr.decode()}"
+        result = subprocess.run(version_nr_call,
+                                capture_output=True,
+                                check=True)
+    except subprocess.CalledProcessError as exc:
+        msg = str(exc)
+        if exc.stdout:
+            msg += f'\noutput:{exc.stdout.decode()}'
+        if exc.stderr:
+            msg += f'\nerrors:\n{exc.stderr.decode()}'
         raise NoCompilerVersionFoundError(msg) from None
-    output = result.stdout.decode().strip()
-    version_nr_ = re.search(r"GNU Fortran.*\) (\d+\.\d+\.\d+)", output)
-    if version_nr_ is None:
-        raise NoCompilerVersionFoundError(
-            f"Could not determine version from {output}")
-    version_nr_str = version_nr_.group(1)
-    mpifort_version = Version(version_nr_str.strip())
 
-    return mpifort_version
+    output = result.stdout.decode().strip()
+    match_ = re.match(r'GNU Fortran.*\) (?P<version>\d+\.\d+\.\d+)',
+                      output)
+    if not match_:
+        raise NoCompilerVersionFoundError('Could not determine version '
+                                          f'from\n{output}')
+    return Version(match_['version'])
 
 
 def wrap_fortran_line(string):

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -12,6 +12,7 @@ __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2024-08-26'
 __license__ = 'GPLv3+'
 
+import re
 import subprocess
 import shutil
 
@@ -53,19 +54,20 @@ def wrap_fortran_line(string):
 def get_mpifort_version():
     """Check the version of the mpifort compiler."""
     # use sed to extract the version number; standard GNU util
-    version_nr_call = [
-        r'mpifort --version | sed -n "s/^GNU Fortran.*) \([0-9.]*\).*/\1/p"']
-
+    version_nr_call = ['mpifort', '--version']
     # check if mpifort is installed
     if not shutil.which('mpifort'):
         raise CompilerNotFoundError
 
     # get version number
     try:
-        version_nr_str = subprocess.run(version_nr_call, shell=True, check=True,
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = subprocess.run(
+            version_nr_call, shell=False, check=True, capture_output=True
+        )
     except subprocess.CalledProcessError:
         raise NoCompilerVersionFoundError
-    mpifort_version = Version(version_nr_str.stdout.decode().strip())
+    output = result.stdout.decode().strip()
+    version_nr_str = re.search(r"GNU Fortran.*\) (\d+\.\d+\.\d+)", output)
+    mpifort_version = Version(version_nr_str.strip())
 
     return mpifort_version

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -16,7 +16,7 @@ import re
 import subprocess
 import shutil
 
-from .version import Version
+from viperleed.calc.lib.version import Version
 
 _FORTRAN_LINE_LENGTH = 72  # FORTRAN line-length limit
 _F77_CONTINUATION_POS = 6  # Column of the continuation character

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -19,13 +19,17 @@ from .version import Version
 _FORTRAN_LINE_LENGTH = 72  # FORTRAN line-length limit
 _F77_CONTINUATION_POS = 6  # Column of the continuation character
 
-class MpifortNotFoundError(Exception):
 
-    """Raised when the mpifort compiler is not found."""
+class FortranCompilerError(Exception):
+    """Base class for exceptions related to the Fortran compiler(s)."""
 
 
-class CouldNotDeterminMpifortVersionError(Exception):
-    """Raised when the mpifort version could not be determined."""
+class CompilerNotFoundError(FortranCompilerError):
+    """Raised when the Fortran compiler is not found."""
+
+
+class NoCompilerVersionFoundError(FortranCompilerError):
+    """Raised when the Fortran version could not be determined."""
 
 
 def wrap_fortran_line(string):
@@ -56,14 +60,14 @@ def get_mpifort_version():
     try:
         subprocess.run(check_for_mpifort_call, shell=True, check=True)
     except subprocess.CalledProcessError:
-        raise MpifortNotFoundError
+        raise CompilerNotFoundError
 
     # get version number
     try:
         version_nr_str = subprocess.run(version_nr_call, shell=True, check=True,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except subprocess.CalledProcessError:
-        raise CouldNotDeterminMpifortVersionError
+        raise NoCompilerVersionFoundError
     mpifort_version = Version(version_nr_str.stdout.decode().strip())
 
     return mpifort_version

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -54,7 +54,11 @@ def get_mpifort_version():
             msg += f"\nerrors:\n{err.stderr.decode()}"
         raise NoCompilerVersionFoundError(msg) from None
     output = result.stdout.decode().strip()
-    version_nr_str = re.search(r"GNU Fortran.*\) (\d+\.\d+\.\d+)", output)
+    version_nr_ = re.search(r"GNU Fortran.*\) (\d+\.\d+\.\d+)", output)
+    if version_nr_ is None:
+        raise NoCompilerVersionFoundError(
+            f"Could not determine version from {output}")
+    version_nr_str = version_nr_.group(1)
     mpifort_version = Version(version_nr_str.strip())
 
     return mpifort_version

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -13,6 +13,7 @@ __created__ = '2024-08-26'
 __license__ = 'GPLv3+'
 
 import subprocess
+import shutil
 
 from .version import Version
 
@@ -51,15 +52,12 @@ def wrap_fortran_line(string):
 
 def get_mpifort_version():
     """Check the version of the mpifort compiler."""
-    check_for_mpifort_call = ['mpifort --version']
     # use sed to extract the version number; standard GNU util
     version_nr_call = [
         r'mpifort --version | sed -n "s/^GNU Fortran.*) \([0-9.]*\).*/\1/p"']
 
     # check if mpifort is installed
-    try:
-        subprocess.run(check_for_mpifort_call, shell=True, check=True)
-    except subprocess.CalledProcessError:
+    if not shutil.which('mpifort'):
         raise CompilerNotFoundError
 
     # get version number

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -46,8 +46,13 @@ def get_mpifort_version():
         result = subprocess.run(
             version_nr_call, shell=False, check=True, capture_output=True
         )
-    except subprocess.CalledProcessError:
-        raise NoCompilerVersionFoundError
+    except subprocess.CalledProcessError as err:
+        msg = str(err)
+        if err.stdout:
+            msg += f"\noutput:{err.stdout.decode()}"
+        if err.stderr:
+            msg += f"\nerrors:\n{err.stderr.decode()}"
+        raise NoCompilerVersionFoundError(msg) from None
     output = result.stdout.decode().strip()
     version_nr_str = re.search(r"GNU Fortran.*\) (\d+\.\d+\.\d+)", output)
     mpifort_version = Version(version_nr_str.strip())

--- a/src/viperleed/calc/lib/fortran_utils.py
+++ b/src/viperleed/calc/lib/fortran_utils.py
@@ -18,11 +18,11 @@ from .version import Version
 _FORTRAN_LINE_LENGTH = 72  # FORTRAN line-length limit
 _F77_CONTINUATION_POS = 6  # Column of the continuation character
 
-class GFortranNotFoundError(Exception):
-    """Raised when the gfortran compiler is not found."""
+class MpifortNotFoundError(Exception):
+    """Raised when the mpifort compiler is not found."""
 
-class CouldNotDeterminGFortranVersionError(Exception):
-    """Raised when the gfortran version could not be determined."""
+class CouldNotDeterminMpifortVersionError(Exception):
+    """Raised when the mpifort version could not be determined."""
 
 def wrap_fortran_line(string):
     """Wrap a FORTRAN string into continuation lines with ampersands."""
@@ -41,15 +41,16 @@ def wrap_fortran_line(string):
     return head + sep.join(continuation_lines)
 
 
-def get_gfortran_version():
-    """Check the version of the gfortran compiler."""
-    check_for_gfortran_call = ['gfortran --version']
+def get_mpifort_version():
+    """Check the version of the mpifort compiler."""
+    check_for_mpifort_call = ['mpifort --version']
+    # use sed to extract the version number; standard GNU util
     version_nr_call = [
-        r'gfortran --version | sed -n "s/^GNU Fortran.*) \([0-9.]*\).*/\1/p"']
+        r'mpifort --version | sed -n "s/^GNU Fortran.*) \([0-9.]*\).*/\1/p"']
 
-    # check if gfortran is installed
+    # check if mpifort is installed
     try:
-        subprocess.run(check_for_gfortran_call, shell=True, check=True)
+        subprocess.run(check_for_mpifort_call, shell=True, check=True)
     except subprocess.CalledProcessError:
         raise GFortranNotFoundError
 
@@ -59,6 +60,6 @@ def get_gfortran_version():
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except subprocess.CalledProcessError:
         raise CouldNotDeterminGFortranVersionError
-    gfortran_version = Version(version_nr_str.stdout.decode().strip())
+    mpifort_version = Version(version_nr_str.stdout.decode().strip())
 
-    return gfortran_version
+    return mpifort_version

--- a/tests/calc/lib/test_fortran_utils.py
+++ b/tests/calc/lib/test_fortran_utils.py
@@ -1,6 +1,7 @@
 """Tests for module fortran_utils of viperleed.calc.lib."""
 
 __authors__ = (
+    'Alexander M. Imre (@amimre)',
     'Michele Riva (@michele-riva)',
     )
 __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
@@ -59,52 +60,58 @@ class TestWrapFortranLine:  # pylint: disable=too-few-public-methods
         """Check expected outcome with valid arguments."""
         assert wrap_fortran_line(string) == expect
 
+
 class TestGetMpifortVersion:
+    """Tests for the get_mpifort_version function."""
+
+    mock_version = '13.2.0'
+    check_exists_cmd = 'mpifort --version'
+    pull_version_cmd = 'mpifort --version | sed'
+
+    @staticmethod
+    def mock_run_fails(cmd, **_):
+        """Simulate a failed subprocess.run."""
+        raise subprocess.CalledProcessError(1, cmd)
+
+    def mock_run_success(self, cmd, **_):
+        """Simulate a successful subprocess.run."""
+        cmd_str = ' '.join(cmd)
+        if self.pull_version_cmd in cmd_str:
+            # Simulate the expected output for version extraction
+            result = f'{self.mock_version}\n'.encode()
+            return subprocess.CompletedProcess(args=cmd,
+                                               returncode=0,
+                                               stdout=result)
+        return self.mock_mpifort_exists_ok(cmd)
+
+    def mock_mpifort_exists_ok(self, cmd, **_):
+        """Simulate a successful check for the existence of mpifort."""
+        if self.check_exists_cmd in cmd:
+            # Simulate the initial check call
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+        raise ValueError(f'Unexpected command {cmd}')
+
     def test_get_mpifort_version_success(self, monkeypatch):
         """Test successful retrieval of mpifort version."""
-
-        # Mock function to simulate subprocess.run behavior
-        def mock_run_success(cmd, shell, check, stdout=None, stderr=None):
-            if "mpifort --version | sed" in " ".join(cmd):
-                # Simulate the expected output for version extraction
-                return subprocess.CompletedProcess(
-                    args=cmd, returncode=0, stdout=b"13.2.0\n"
-                )
-            elif "mpifort --version" in " ".join(cmd):
-                # Simulate the initial check call
-                return subprocess.CompletedProcess(args=cmd, returncode=0)
-            raise ValueError("Unexpected command")  # Catch unexpected calls
-
-        monkeypatch.setattr(subprocess, "run", mock_run_success)
-
-        # Run the function and check the version output
-        version = get_mpifort_version()
-        assert str(version) == "13.2.0"
-
+        monkeypatch.setattr(subprocess, 'run', self.mock_run_success)
+        assert get_mpifort_version() == self.mock_version
 
     def test_get_mpifort_version_not_installed(self, monkeypatch):
         """Test behavior when mpifort is not installed."""
-
-        def mock_run_not_installed(cmd, shell, check, stdout=None, stderr=None):
-            raise subprocess.CalledProcessError(1, cmd)
-
-        monkeypatch.setattr(subprocess, "run", mock_run_not_installed)
+        monkeypatch.setattr(subprocess, 'run', self.mock_run_fails)
         with pytest.raises(MpifortNotFoundError):
             get_mpifort_version()
 
-
     def test_get_mpifort_version_could_not_determine(self, monkeypatch):
         """Test behavior when mpifort version cannot be determined."""
+        def mock_run_could_not_determine(cmd, **_):
+            """Fail only on version check."""
+            try:
+                return self.mock_mpifort_exists_ok(cmd)
+            except ValueError:
+                pass
+            return self.mock_run_fails(cmd)
 
-        def mock_run_could_not_determine(
-            cmd, shell, check, stdout=None, stderr=None
-        ):
-            if "mpifort --version" in cmd:
-                return subprocess.CompletedProcess(
-                    args=cmd, returncode=0
-                )  # Simulate successful initial check
-            raise subprocess.CalledProcessError(1, cmd)
-
-        monkeypatch.setattr(subprocess, "run", mock_run_could_not_determine)
+        monkeypatch.setattr(subprocess, 'run', mock_run_could_not_determine)
         with pytest.raises(CouldNotDeterminMpifortVersionError):
             get_mpifort_version()

--- a/tests/calc/lib/test_fortran_utils.py
+++ b/tests/calc/lib/test_fortran_utils.py
@@ -91,18 +91,18 @@ class TestGetMpifortVersion:
             return subprocess.CompletedProcess(args=cmd, returncode=0)
         raise ValueError(f'Unexpected command {cmd}')
 
-    def test_get_mpifort_version_success(self, monkeypatch):
+    def test_success(self, monkeypatch):
         """Test successful retrieval of mpifort version."""
         monkeypatch.setattr(subprocess, 'run', self.mock_run_success)
         assert get_mpifort_version() == self.mock_version
 
-    def test_get_mpifort_version_not_installed(self, monkeypatch):
+    def test_not_installed(self, monkeypatch):
         """Test behavior when mpifort is not installed."""
         monkeypatch.setattr(subprocess, 'run', self.mock_run_fails)
         with pytest.raises(MpifortNotFoundError):
             get_mpifort_version()
 
-    def test_get_mpifort_version_could_not_determine(self, monkeypatch):
+    def test_could_not_determine(self, monkeypatch):
         """Test behavior when mpifort version cannot be determined."""
         def mock_run_could_not_determine(cmd, **_):
             """Fail only on version check."""

--- a/tests/calc/lib/test_fortran_utils.py
+++ b/tests/calc/lib/test_fortran_utils.py
@@ -7,6 +7,8 @@ __authors__ = (
 __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2024-08-26'
 __license__ = 'GPLv3+'
+
+import shutil
 import subprocess
 
 import pytest
@@ -15,7 +17,15 @@ from pytest_cases import parametrize
 from viperleed.calc.lib.fortran_utils import wrap_fortran_line
 from viperleed.calc.lib.fortran_utils import get_mpifort_version
 from viperleed.calc.lib.fortran_utils import MpifortNotFoundError
-from viperleed.calc.lib.fortran_utils import CouldNotDeterminMpifortVersionError
+from viperleed.calc.lib.fortran_utils import (
+    CouldNotDeterminMpifortVersionError
+    )
+
+from ...helpers import not_raises
+
+
+with_mpifort = pytest.mark.skipif(not shutil.which('mpifort'),
+                                  reason='no mpifort installed')
 
 
 class TestWrapFortranLine:  # pylint: disable=too-few-public-methods
@@ -95,6 +105,12 @@ class TestGetMpifortVersion:
         """Test successful retrieval of mpifort version."""
         monkeypatch.setattr(subprocess, 'run', self.mock_run_success)
         assert get_mpifort_version() == self.mock_version
+
+    @with_mpifort
+    def test_success_dont_mock(self):
+        """Run a realistic version check when mpifort exists."""
+        with not_raises(CouldNotDeterminMpifortVersionError):
+            get_mpifort_version()
 
     def test_not_installed(self, monkeypatch):
         """Test behavior when mpifort is not installed."""

--- a/tests/calc/lib/test_fortran_utils.py
+++ b/tests/calc/lib/test_fortran_utils.py
@@ -18,7 +18,7 @@ from viperleed.calc.lib.fortran_utils import wrap_fortran_line
 from viperleed.calc.lib.fortran_utils import get_mpifort_version
 from viperleed.calc.lib.fortran_utils import MpifortNotFoundError
 from viperleed.calc.lib.fortran_utils import (
-    CouldNotDeterminMpifortVersionError
+    CouldNotDetermineMpifortVersionError
     )
 
 from ...helpers import not_raises
@@ -109,7 +109,7 @@ class TestGetMpifortVersion:
     @with_mpifort
     def test_success_dont_mock(self):
         """Run a realistic version check when mpifort exists."""
-        with not_raises(CouldNotDeterminMpifortVersionError):
+        with not_raises(CouldNotDetermineMpifortVersionError):
             version = get_mpifort_version()
         assert any(part > 0 for part in version)
 
@@ -130,5 +130,5 @@ class TestGetMpifortVersion:
             return self.mock_run_fails(cmd)
 
         monkeypatch.setattr(subprocess, 'run', mock_run_could_not_determine)
-        with pytest.raises(CouldNotDeterminMpifortVersionError):
+        with pytest.raises(CouldNotDetermineMpifortVersionError):
             get_mpifort_version()

--- a/tests/calc/lib/test_fortran_utils.py
+++ b/tests/calc/lib/test_fortran_utils.py
@@ -17,8 +17,8 @@ import pytest
 from pytest_cases import parametrize
 
 from viperleed.calc.lib.fortran_utils import CompilerNotFoundError
-from viperleed.calc.lib.fortran_utils import get_mpifort_version
 from viperleed.calc.lib.fortran_utils import NoCompilerVersionFoundError
+from viperleed.calc.lib.fortran_utils import get_mpifort_version
 from viperleed.calc.lib.fortran_utils import wrap_fortran_line
 
 from ...helpers import not_raises

--- a/tests/calc/lib/test_fortran_utils.py
+++ b/tests/calc/lib/test_fortran_utils.py
@@ -14,12 +14,10 @@ import subprocess
 import pytest
 from pytest_cases import parametrize
 
-from viperleed.calc.lib.fortran_utils import wrap_fortran_line
+from viperleed.calc.lib.fortran_utils import CompilerNotFoundError
 from viperleed.calc.lib.fortran_utils import get_mpifort_version
-from viperleed.calc.lib.fortran_utils import MpifortNotFoundError
-from viperleed.calc.lib.fortran_utils import (
-    CouldNotDetermineMpifortVersionError
-    )
+from viperleed.calc.lib.fortran_utils import NoCompilerVersionFoundError
+from viperleed.calc.lib.fortran_utils import wrap_fortran_line
 
 from ...helpers import not_raises
 
@@ -109,14 +107,14 @@ class TestGetMpifortVersion:
     @with_mpifort
     def test_success_dont_mock(self):
         """Run a realistic version check when mpifort exists."""
-        with not_raises(CouldNotDetermineMpifortVersionError):
+        with not_raises(NoCompilerVersionFoundError):
             version = get_mpifort_version()
         assert any(part > 0 for part in version)
 
     def test_not_installed(self, monkeypatch):
         """Test behavior when mpifort is not installed."""
         monkeypatch.setattr(subprocess, 'run', self.mock_run_fails)
-        with pytest.raises(MpifortNotFoundError):
+        with pytest.raises(CompilerNotFoundError):
             get_mpifort_version()
 
     def test_could_not_determine(self, monkeypatch):
@@ -130,5 +128,5 @@ class TestGetMpifortVersion:
             return self.mock_run_fails(cmd)
 
         monkeypatch.setattr(subprocess, 'run', mock_run_could_not_determine)
-        with pytest.raises(CouldNotDetermineMpifortVersionError):
+        with pytest.raises(NoCompilerVersionFoundError):
             get_mpifort_version()

--- a/tests/calc/lib/test_fortran_utils.py
+++ b/tests/calc/lib/test_fortran_utils.py
@@ -110,7 +110,8 @@ class TestGetMpifortVersion:
     def test_success_dont_mock(self):
         """Run a realistic version check when mpifort exists."""
         with not_raises(CouldNotDeterminMpifortVersionError):
-            get_mpifort_version()
+            version = get_mpifort_version()
+        assert any(part > 0 for part in version)
 
     def test_not_installed(self, monkeypatch):
         """Test behavior when mpifort is not installed."""


### PR DESCRIPTION
As discussed in issue #44, there can be issues with the used compiler flag `-fallow-argument-mismatch`, as it does not exist for gfortran (and thus mpifort) versions <10.0. For newer versions though, compilation may error out if the flag is not provided.
This adds a check for the version and only supplies the option if a high enough version is detected.