### PR TITLE
Use all hardware threads with Open MPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,8 @@ pythonpath = ['.', '..']
 filterwarnings = ['error',]
 required_plugins = [
     'pytest-cases>=3.8.1',  # 3.8.1 fixes some ScopeMismatch
-    'pytest-subtests'
+    'pytest-mock>=3',
+    'pytest-subtests',
     ]
 xfail_strict = true
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,4 +3,5 @@
 ase            # Used for testing the ASE interface
 pytest<8       # Till Issue #337 of pytest-cases is fixed
 pytest-cases
+pytest-mock>=3
 pytest-subtests

--- a/src/viperleed/calc/files/parameters/checker.py
+++ b/src/viperleed/calc/files/parameters/checker.py
@@ -11,9 +11,16 @@ __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2023-10-25'
 __license__ = 'GPLv3+'
 
+import logging
 import operator
 
+from viperleed.calc.lib.base import available_cpu_count   # For N_CORES
+from viperleed.calc.lib.string_utils import parent_name
+
 from .errors import ParameterConflictError
+
+
+_LOGGER = logging.getLogger(parent_name(__name__))
 
 
 # About the disable: ParametersChecker has only one single job:
@@ -66,3 +73,18 @@ class ParametersChecker:
         pre, post = self._rpars.FORTRAN_COMP_MPI
         if not post and pre in {'mpifort', 'mpiifort'}:
             self._rpars.getFortranMpiComp(comp=pre)
+
+    def _check_n_cores(self):
+        """Warn if N_CORES is larger than the number of available CPUs."""
+        n_cores = self._rpars.N_CORES
+        available = available_cpu_count()
+        if not n_cores or available <= 0:
+            # Will auto-detect, or detection failed
+            return
+        if n_cores > available:
+            _LOGGER.warning(
+                f'The N_CORES parameter is set to {n_cores}, which is larger '
+                f'than the number of available processors ({available}). This '
+                'may not be ideal for performance, or may render execution '
+                'impossible. Consider reducing N_CORES.'
+                )

--- a/src/viperleed/calc/sections/search.py
+++ b/src/viperleed/calc/sections/search.py
@@ -80,7 +80,7 @@ class TensErLEEDSearchError(SearchError):
 
 
 class InconsistentV0ImagError(SearchParameterError, TensErLEEDSearchError):
-    """The VOi value in PARAMETERS does not match the one in the Deltas."""
+    """The V0i value in PARAMETERS does not match the one in the Deltas."""
 
     detailed_message = (
         'TensErLEED search stopped because stored Delta files were calculated '

--- a/src/viperleed/calc/sections/search.py
+++ b/src/viperleed/calc/sections/search.py
@@ -129,7 +129,7 @@ class ProcessKilledError(SearchError):
         )
     _matcher = any  # Two different error messages for Intel and GNU
     log_records = (
-        'YOUR APPLICATION TERMINATED WITH THE EXIT STRING: Killed (signal 9)',
+        'APPLICATION TERMINATED WITH THE EXIT STRING: Killed (signal 9)',
         '=   KILLED BY SIGNAL: 9 (Killed)',
         )
 

--- a/src/viperleed/calc/sections/search.py
+++ b/src/viperleed/calc/sections/search.py
@@ -96,12 +96,12 @@ class MaxIntensitiesError(SearchParameterError, TensErLEEDSearchError):
 
     detailed_message = (
         'TensErLEED stopped due to unreasonably high beam amplitudes.\n'
-        'This may be causes by convergence problems due to a too small '
+        'This may be caused by convergence problems due to a too small '
         'value of LMAX. Alternatively, this error may be caused either '
         'by scatterers with very small distances as a result of a very '
         'large range used in DISPLACEMENTS. Check your input files and '
         'consider increasing LMAX or decreasing the DISPLACEMENTS ranges.'
-       )
+        )
     log_records = ('MAX. INTENS. IN THEOR. BEAM',
                    'IS SUSPECT',
                    '****** STOP PROGRAM ******')
@@ -121,10 +121,10 @@ class ProcessKilledError(SearchError):
     """The mpirun process died. Typically, it required too much memory."""
 
     detailed_message = (
-        'The search was stopped because the MPI process was killed by system. '
-        'This is most likely because the process ran out of available memory. '
-        'Consider reducing the number of MPI processes by setting a lower '
-        'value for N_CORES or limiting the parameter space in the '
+        'The search was stopped because the MPI process was killed by the '
+        'system. This is most likely because the process ran out of available '
+        'memory. Consider reducing the number of MPI processes by setting a '
+        'smaller value for N_CORES or limiting the parameter space in the '
         'DISPLACEMENTS file.'
         )
     _matcher = any  # Two different error messages for Intel and GNU
@@ -361,8 +361,8 @@ def _check_search_log(search_log_path):
     Raises
     ------
     SearchError
-        If an error message is found in the search log file that
-        corresponds to a fatal error (from TensErLEED or other
+        If error messages are found in the log file at `search_log_path`
+        that correspond to a fatal error (from TensErLEED or other
         source).
     """
     if not search_log_path:
@@ -769,7 +769,7 @@ def search(sl, rp):
         rp.setHaltingLevel(3)
         return None
 
-    # check for mpirun, decide whether to use parallelization
+    # Decide whether to use parallelization
     usempi = rp.N_CORES > 1 and shutil.which('mpirun')
     if not usempi:
         reason = (
@@ -826,13 +826,12 @@ def search(sl, rp):
 
         randname = 'MPIrandom_.o' if usempi else 'random_.o'
         if rp.TL_VERSION <= Version('1.7.3'):
-            # these are short C scripts - use pre-compiled versions
-
-            # try to copy randomizer lib object file
+            # Try to copy randomizer lib object file
+            # These are short C scripts - use pre-compiled versions
             try:
                 shutil.copy2(libpath / randname, randname)
             except FileNotFoundError:
-                logger.error('Could not find required random_.o object file. '
+                logger.error(f'Could not find required {randname} file. '
                              'You may have forgotten to compile random_.c.')
                 raise
 

--- a/src/viperleed/calc/sections/search.py
+++ b/src/viperleed/calc/sections/search.py
@@ -107,6 +107,16 @@ class MaxIntensitiesError(SearchParameterError, TensErLEEDSearchError):
                    '****** STOP PROGRAM ******')
 
 
+class NotEnoughSlotsError(SearchParameterError):
+    """Could not spawn the requested N_CORES Open MPI processes."""
+
+    detailed_message = (
+        'GNU mpirun failed to allocate the number of processes '
+        'requested via N_CORES. Try reducing the N_CORES parameter.'
+        )
+    log_records = ('There are not enough slots available in the system',)
+
+
 class ProcessKilledError(SearchError):
     """The mpirun process died. Typically, it required too much memory."""
 
@@ -371,6 +381,7 @@ def _check_search_log(search_log_path):
         SigbusError,
         InconsistentV0ImagError,
         ProcessKilledError,
+        NotEnoughSlotsError,
         )
     try:
         raise next(e for e in _known_errors if e.matches(log_contents))

--- a/tests/calc/files/parameters/test_checker.py
+++ b/tests/calc/files/parameters/test_checker.py
@@ -18,6 +18,8 @@ from viperleed.calc.files.parameters.errors import ParameterConflictError
 
 from ....helpers import not_raises
 
+_MODULE = 'viperleed.calc.files.parameters.checker'
+
 
 @fixture(name='rpars_with_attrs', scope='session')
 def factory_rpars_with_attrs():
@@ -106,3 +108,42 @@ class TestFortraCompUpdated:
         checker.check_parameter_conflicts(rpars)
         mock_mpi.assert_called_once()
         mock_non_mpi.assert_called_once()
+
+
+class TestNCoresChecked:
+    """Ensure that N_CORES is checked against the number of CPUs."""
+
+    def test_not_defined(self, checker, rpars_with_attrs, caplog):
+        """Test that no check is performed when N_CORES is undefined."""
+        rpars = rpars_with_attrs()
+        checker.check_parameter_conflicts(rpars)
+        assert not caplog.text
+
+    @parametrize(cpus=(0, -1))
+    # pylint: disable-next=too-many-arguments  # 4/6 are fixtures
+    def test_fail_to_detect(self, cpus, checker, rpars_with_attrs,
+                            caplog, monkeypatch):
+        """Test that no check is performed when failing to detect CPUs."""
+        rpars = rpars_with_attrs(N_CORES=5)
+        monkeypatch.setattr(f'{_MODULE}.available_cpu_count',
+                            MagicMock(return_value=cpus))
+        checker.check_parameter_conflicts(rpars)
+        assert not caplog.text
+
+    def test_enough_cpus(self, checker, rpars_with_attrs, caplog, monkeypatch):
+        """Check no warnings with N_CORES < nr. CPUs."""
+        rpars = rpars_with_attrs(N_CORES=5)
+        monkeypatch.setattr(f'{_MODULE}.available_cpu_count',
+                            MagicMock(return_value=10))
+        checker.check_parameter_conflicts(rpars)
+        assert not caplog.text
+
+    def test_too_few_cpus(self, checker, rpars_with_attrs,
+                          caplog, monkeypatch):
+        """Check no warnings with N_CORES < nr. CPUs."""
+        rpars = rpars_with_attrs(N_CORES=5)
+        monkeypatch.setattr(f'{_MODULE}.available_cpu_count',
+                            MagicMock(return_value=1))
+        checker.check_parameter_conflicts(rpars)
+        msg = 'Consider reducing N_CORES'
+        assert msg in caplog.text

--- a/tests/calc/files/parameters/test_checker.py
+++ b/tests/calc/files/parameters/test_checker.py
@@ -69,7 +69,7 @@ class TestElementConflicts:
             checker.check_parameter_conflicts(rpars)
 
 
-class TestFortraCompUpdated:
+class TestFortranCompUpdated:
     """Check that FORTRAN_COMP is updated by the checker."""
 
     _unchanged = {

--- a/tests/calc/lib/test_fortran_utils.py
+++ b/tests/calc/lib/test_fortran_utils.py
@@ -11,7 +11,6 @@ __license__ = 'GPLv3+'
 import shutil
 from subprocess import CalledProcessError
 from subprocess import CompletedProcess
-from unittest.mock import MagicMock
 
 import pytest
 from pytest_cases import parametrize
@@ -60,10 +59,10 @@ class TestGetMpifortVersion:
                                     stdout=result.encode())
         raise ValueError(f'Unexpected command {cmd}')
 
-    def test_success(self, monkeypatch):
+    def test_success(self, mocker):
         """Test successful retrieval of mpifort version."""
-        monkeypatch.setattr('shutil.which', MagicMock(return_value=True))
-        monkeypatch.setattr('subprocess.run', self.mock_run_success)
+        mocker.patch('shutil.which', return_value=True)
+        mocker.patch('subprocess.run', new=self.mock_run_success)
         version = get_mpifort_version()
         assert version == self.mock_version
 
@@ -74,17 +73,17 @@ class TestGetMpifortVersion:
             version = get_mpifort_version()
         assert any(part > 0 for part in version)
 
-    def test_not_installed(self, monkeypatch):
+    def test_not_installed(self, mocker):
         """Test behavior when mpifort is not installed."""
-        monkeypatch.setattr('shutil.which', MagicMock(return_value=None))
+        mocker.patch('shutil.which', return_value=None)
         with pytest.raises(CompilerNotFoundError):
             get_mpifort_version()
 
     @parametrize(fake_run=('mock_run_no_version', 'mock_run_fails'))
-    def test_could_not_determine(self, fake_run, monkeypatch):
+    def test_could_not_determine(self, fake_run, mocker):
         """Test behavior when mpifort version cannot be determined."""
-        monkeypatch.setattr('shutil.which', MagicMock(return_value=True))
-        monkeypatch.setattr('subprocess.run', getattr(self, fake_run))
+        mocker.patch('shutil.which', return_value=True)
+        mocker.patch('subprocess.run', new=getattr(self, fake_run))
         with pytest.raises(NoCompilerVersionFoundError):
             get_mpifort_version()
 

--- a/tests/calc/sections/test_search.py
+++ b/tests/calc/sections/test_search.py
@@ -8,7 +8,29 @@ __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2023-07-28'
 __license__ = 'GPLv3+'
 
+from functools import partial
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
 import pytest
+from pytest_cases import parametrize
+
+from viperleed.calc.sections.search import InconsistentV0ImagError
+from viperleed.calc.sections.search import MaxIntensitiesError
+from viperleed.calc.sections.search import NotEnoughSlotsError
+from viperleed.calc.sections.search import ProcessKilledError
+from viperleed.calc.sections.search import SearchError
+from viperleed.calc.sections.search import SigbusError
+from viperleed.calc.sections.search import _check_search_log
+
+from ...helpers import not_raises
+
+
+def patch_read(log_contents):
+    """Make Path.read_text return `log_contents`."""
+    return patch('pathlib.Path.read_text',
+                 MagicMock(return_value=log_contents))
+
 
 class TestSearchAg100:
     """Check the successful outcome of a structure optimization for Ag(100)."""
@@ -19,20 +41,83 @@ class TestSearchAg100:
         assert search_files_ag100.records is not None
         assert search_files_ag100.records.get_last_section_state('search')
 
-    @pytest.mark.parametrize('expected_file', ('search.steu',))
+    @parametrize('expected_file', ('search.steu',))
     def test_search_input_exist(self, search_files_ag100, expected_file):
         """Make sure input files were generated."""
         assert search_files_ag100.expected_file_exists(expected_file)
 
-    @pytest.mark.parametrize('expected_file', ('SD.TL', 'control.chem'))
+    @parametrize('expected_file', ('SD.TL', 'control.chem'))
     def test_search_raw_files_exist(self, search_files_ag100, expected_file):
         """Make sure the expected output files are present."""
         assert search_files_ag100.expected_file_exists(expected_file)
 
-    @pytest.mark.parametrize(
-        'expected_file',
-        ('Search-report.pdf', 'Search-progress.pdf')
-        )
+    @parametrize('expected_file', ('Search-report.pdf', 'Search-progress.pdf'))
     def test_search_pdf_files_exist(self, search_files_ag100, expected_file):
         """Make sure the expected PDF report files are present."""
         assert search_files_ag100.expected_file_exists(expected_file)
+
+
+class TestCheckSearchLog:
+    """Tests for the _check_search_log function."""
+
+    @parametrize(path=(None, ''))
+    def test_no_log(self, path):
+        """Check no complaints if there is no log file."""
+        with not_raises(SearchError):
+            _check_search_log(path)
+
+    def test_cannot_open_file(self, caplog):
+        """Check logging when failing to open a log file."""
+        with patch_read('Some log data') as mock_read:
+            mock_read.side_effect = OSError
+            _check_search_log('does_not_exist')
+            assert 'Could not read search log' in caplog.text
+
+    _log_faulty = {
+        'max intensity': (
+            MaxIntensitiesError,
+            'MAX. INTENS. IN THEOR. BEAM <kdsv1jb<v IS SUSPECT bcjab\n'
+            '****** STOP PROGRAM ****** <sò48+jvblk< vh',
+            ),
+        'sigbus': (
+            SigbusError,
+            'received signal SIGBUS <sn6ò undefined portion of a memory object'
+            ),
+        'v0i': (
+            InconsistentV0ImagError,
+            'Average optical potential value in rf.info is incorrect:',
+            ),
+        'killed Intel': (
+            ProcessKilledError,
+            'APPLICATION TERMINATED WITH THE EXIT STRING: Killed (signal 9)',
+            ),
+        'killed GNU': (ProcessKilledError,
+                       '=   KILLED BY SIGNAL: 9 (Killed)'),
+        'slots': (NotEnoughSlotsError,
+                  'There are not enough slots available in the system'),
+        }
+
+    @parametrize('exc,log_contents', _log_faulty.values(), ids=_log_faulty)
+    def test_raises(self, exc, log_contents):
+        """Check that `exc` is raised for given log-file contents."""
+        with pytest.raises(exc), patch_read(log_contents):
+            _check_search_log('some_log_file')
+
+    _no_errors = {
+        'truly no error': 'No errors',
+        'max intensity, truncated_1': 'MAX. INTENS. IN THEOR. BEAM',
+        'max intensity, truncated_2': 'BEAM <kdsv1jb<v IS SUSPECT',
+        'max intensity, truncated_3': 'b\n****** STOP PROGRAM',
+        'sigbus, truncated_1': 'received signal SIGBUS',
+        'sigbus, truncated_2': 'SIGBUS <sn6ò undefined portion',
+        'v0i, truncated': 'Average optical potential incorrect:',
+        'killed Intel, truncated': 'EXIT STRING: Killed (signal 9)',
+        'killed GNU, truncated': 'BY SIGNAL: 9',
+        'slots, truncated': 'not enough slots',
+        }
+
+    @parametrize(log_contents=_no_errors.values(), ids=_no_errors)
+    def test_no_errors(self, log_contents):
+        """Check successful processing of an error-free log."""
+        with not_raises(SearchError), patch_read(log_contents):
+            _check_search_log('some_log_file')

--- a/tests/calc/sections/test_search.py
+++ b/tests/calc/sections/test_search.py
@@ -8,7 +8,6 @@ __copyright__ = 'Copyright (c) 2019-2024 ViPErLEED developers'
 __created__ = '2023-07-28'
 __license__ = 'GPLv3+'
 
-from functools import partial
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -68,10 +67,11 @@ class TestCheckSearchLog:
 
     def test_cannot_open_file(self, caplog):
         """Check logging when failing to open a log file."""
+        msg = 'Could not read search log'
         with patch_read('Some log data') as mock_read:
             mock_read.side_effect = OSError
             _check_search_log('does_not_exist')
-            assert 'Could not read search log' in caplog.text
+            assert msg in caplog.text
 
     _log_faulty = {
         'max intensity': (


### PR DESCRIPTION
This PR addresses a problem that surfaced in the context of #44, specifically https://github.com/viperleed/viperleed/issues/44#issuecomment-2457638938.

This PR implements the suggestion as in https://github.com/viperleed/viperleed/issues/44#issuecomment-2459148042.

I originally intended to honor the suggestion by @amimre in https://github.com/viperleed/viperleed/issues/44#issuecomment-2459415952. However the two of us have tested a bit yesterday the addition of the `--use-hwthread-cpus` flag to `mpirun` and came to the conclusion that it is safe to always use, irrespective of whether `N_CORES` was specified or auto-detected.

The concern voiced in https://github.com/viperleed/viperleed/issues/44#issuecomment-2459415952 regarded especially the usage in an HPC environment. Testing on the [VSC-4](https://vsc.ac.at/home/) showed that, on compute nodes that are managed by SLURM, the presence of the `--use-hwthread-cpus` flag has no impact on the number of slots that `mpirun` has access to. I.e., both

```
mpirun --display-map -n 1 true
mpirun --display-map --use-hwthread-cpus -n 1 true
```

give the same number of slots. 

I'm happy to come up with a bit more detailed solution of adding the flag only if `N_CORES` was detected automatically (and error out cleanly otherwise) in case @fkraushofer and @amimre still think it would be better.

Notice that the flag does not imply that Open MPI will do any oversubscription. It will use as many threads as are available from either the nominal count from the CPU manufacturer, or whatever is limited by a task scheduler (like SLURM).