### PR TITLE
Fix allow overwriting POSCAR file in poscar utils

### DIFF
--- a/src/viperleed/utilities/poscar/find_symmetry.py
+++ b/src/viperleed/utilities/poscar/find_symmetry.py
@@ -24,7 +24,8 @@ class FindSymmetryCLI(_PoscarSymmetryCLI, cli_name='find_symmetry'):
 
     def write_output(self, processed_slab, args):
         """Write the detected plane group to the args.outfile."""
-        args.outfile.write(f'{processed_slab.foundplanegroup}\n')
+        with self.outfile_context(args) as f:
+            f.write(f'{processed_slab.foundplanegroup}\n')
 
 
 if __name__ == '__main__':

--- a/src/viperleed/utilities/poscar/vasp_relax.py
+++ b/src/viperleed/utilities/poscar/vasp_relax.py
@@ -61,18 +61,19 @@ class PrepareForVASPRelaxCLI(_PoscarStreamCLI, cli_name='vasp_relax'):
         write_vasp_poscar(processed_slab, args)
 
 
-def write_vasp_poscar(slab, args):
-    """Pipe a Slab to stdout given some command-line arguments."""
-    # What follows is very similar to poscar.write. The reason not
-    # to do this there is to prevent adding a dedicated argument
-    # that would only be used in this specific use case. It would
-    # also complicate uselessly the code: it would need to decide
-    # to use a VASPPOSCARWriter rather than a POSCARFileWriter
-    slab.sort_by_element()
-    relax_info = {'above_c': args.above_c,
-                  'c_only': not args.all_directions}
-    writer = poscar.VASPPOSCARWriter(args.outfile, relax_info=relax_info)
-    writer.write(slab)
+    def write_vasp_poscar(self, slab, args):
+        """Pipe a Slab to stdout given some command-line arguments."""
+        # What follows is very similar to poscar.write. The reason not
+        # to do this there is to prevent adding a dedicated argument
+        # that would only be used in this specific use case. It would
+        # also complicate uselessly the code: it would need to decide
+        # to use a VASPPOSCARWriter rather than a POSCARFileWriter
+        slab.sort_by_element()
+        relax_info = {'above_c': args.above_c,
+                    'c_only': not args.all_directions}
+        with self.outfile_context(args) as outfile:
+            writer = poscar.VASPPOSCARWriter(outfile, relax_info=relax_info)
+            writer.write(slab)
 
 
 if __name__ == '__main__':

--- a/tests/calc/utilities/poscar/test_sort_by_z.py
+++ b/tests/calc/utilities/poscar/test_sort_by_z.py
@@ -13,7 +13,9 @@ import numpy as np
 import pytest_cases
 
 from viperleed.utilities.poscar.sort_by_z import SortByZCLI
+from viperleed.calc.files import poscar
 
+from ....helpers import POSCAR_PATH
 from ... import poscar_slabs
 from ...tags import CaseTag as Tag
 
@@ -33,7 +35,7 @@ def test_sort_by_z(test_slab):
     sorted_slab = SortByZCLI().process_slab(slab, args)
 
     # Check if the slab is sorted by z-coordinate
-    assert np.all(np.diff([at.pos[2] for at in sorted_slab]) <= 0)
+    assert slab_is_sorted(sorted_slab)
 
 @infoless
 def test_sort_by_z_reversed(test_slab):
@@ -47,4 +49,38 @@ def test_sort_by_z_reversed(test_slab):
     sorted_slab = SortByZCLI().process_slab(slab, args)
 
     # Check if the slab is sorted by z-coordinate
-    assert np.all(np.diff([at.pos[2] for at in sorted_slab]) >= 0)
+    assert slab_is_sorted(sorted_slab, reversed=True)
+
+@infoless
+def test_overwrite_file(test_slab, tmp_path):
+    *_, info = test_slab
+    poscar_path = POSCAR_PATH/info.poscar.name
+
+    # copy to a temporary file because we will overwrite the file
+    tmp_poscar_path = tmp_path / info.poscar.name
+    tmp_poscar_path.write_text(poscar_path.read_text())
+
+    sort_by_z_cli = SortByZCLI()
+    # give the temporary file as input and output
+    sort_by_z_cli([
+        '-i', str(tmp_poscar_path),
+        '-o', str(tmp_poscar_path),
+        ])
+
+    # read the modified POSCAR file
+    modified_slab = poscar.read(tmp_poscar_path)
+
+    # Check if the slab is sorted by z-coordinate
+    assert slab_is_sorted(modified_slab)
+
+def slab_is_sorted(slab, reversed=False):
+    """Check if the slab is sorted by z-coordinate."""
+    if reversed:
+        z_order = np.diff([at.pos[2] for at in slab]) >= 0
+    else:
+        z_order = (np.diff([at.pos[2] for at in slab]) <= 0)
+
+    not_same_el = np.array(at1.el != at2.el
+                      for at1, at2 in zip(slab.atlist[:-1], slab.atlist[1:]))
+    print(z_order, not_same_el)
+    return np.all(np.logical_or(z_order, not_same_el))


### PR DESCRIPTION
Fixes #285.

As pointed out by @fkraushofer, there is currently an issue when trying to read and write to the same file using the poscar utilities.
This was because the FileType class from the argparse library opens the file upon parsing the argument. When the same file is selected for reading and writing, it would silently open it twice and erase the contents for the write operation. This is a know problematic behaviour (see https://github.com/python/cpython/issues/58032).
To circumvent this, argpase suggests using pathlib Paths and manual handling, which I do in this fix.

I also added tests that try to read and write from the same file to avoid regression.