### PR TITLE
Prevent bookkeeper logs to spill over to calc

### DIFF
--- a/src/viperleed/calc/bookkeeper/cli.py
+++ b/src/viperleed/calc/bookkeeper/cli.py
@@ -119,7 +119,7 @@ class BookkeeperCLI(ViPErLEEDCLI, cli_name='bookkeeper'):
     def __call__(self, args=None):
         """Call the bookkeeper with command-line args."""
         parsed_args = self.parse_cli_args(args)
-        bookkeeper = Bookkeeper(cwd=Path.cwd().resolve())
+        bookkeeper = Bookkeeper()
         mode = getattr(parsed_args, 'mode', BookkeeperMode.ARCHIVE)
         kwargs = {
             'requires_user_confirmation': not parsed_args.skip_confirmation,

--- a/src/viperleed/calc/files/phaseshifts.py
+++ b/src/viperleed/calc/files/phaseshifts.py
@@ -485,7 +485,7 @@ def __check_consistency_element_order(rp, sl, phaseshifts,
     return may_have_wrong_phaseshifts
 
 
-def writePHASESHIFTS(firstline, phaseshifts, file_path=Path()/'PHASESHIFTS'):
+def writePHASESHIFTS(firstline, phaseshifts, file_path='PHASESHIFTS'):
     """Takes phaseshift data and writes it to a PHASESHIFTS file."""
     _file_path = Path(file_path)
     output = firstline

--- a/src/viperleed/calc/run.py
+++ b/src/viperleed/calc/run.py
@@ -151,7 +151,7 @@ def _finalize_on_early_exit(rpars_or_manifest):
 
 def _get_parent_directory_name():
     """Return the name of the directory above the current one."""
-    _system_name = Path.cwd().resolve().parent.name
+    _system_name = Path.cwd().parent.name
     LOGGER.info('No system name specified. Using name of parent '
                 f'directory: {_system_name}')
     return _system_name

--- a/src/viperleed/calc/run.py
+++ b/src/viperleed/calc/run.py
@@ -113,7 +113,7 @@ def run_calc(
         # Read input files and load user arguments
         rpars, slab = _make_rpars_and_slab(manifest, preset_params, slab, home)
     except Exception:
-        cleanup(manifest)
+        _finalize_on_early_exit(manifest)
         return 2, None
 
     # Load runtime information in rpars
@@ -125,7 +125,7 @@ def run_calc(
     # Check if halting condition is already in effect
     if rpars.halt >= rpars.HALTING:
         logger.info('Halting execution...')
-        cleanup(rpars)
+        _finalize_on_early_exit(rpars)
         return 0, None
 
     rpars.updateDerivedParams()
@@ -140,6 +140,12 @@ def run_calc(
     logging.shutdown()
 
     return exit_code, state_recorder
+
+
+def _finalize_on_early_exit(rpars_or_manifest):
+    """Finish a calc execution before entering the `section_loop`."""
+    cleanup(rpars_or_manifest)
+    close_all_handlers(logger)
 
 
 def _get_parent_directory_name():

--- a/src/viperleed/calc/run.py
+++ b/src/viperleed/calc/run.py
@@ -40,7 +40,6 @@ from viperleed.calc.sections.initialization import (
 from viperleed.calc.sections.run_sections import section_loop
 
 
-
 def run_calc(
     system_name=None,
     console_output=True,
@@ -52,7 +51,7 @@ def run_calc(
     """Run a ViPErLEED calculation in the current directory.
 
     By default, a PARAMETERS and a POSCAR file are expected, but can be
-    replaced by passing the `slab` and/or `present_params` kwargs.
+    replaced by passing the `slab` and/or `preset_params` kwargs.
 
     Parameters
     ----------
@@ -98,129 +97,43 @@ def run_calc(
         terminates before any section is executed.
     """
     os.umask(0)
-    # start logger, write to file:
-    timestamp = DateTimeFormat.FILE_SUFFIX.now()
 
+    # Start logger, write to file:
+    timestamp = DateTimeFormat.FILE_SUFFIX.now()
     log_name = f'{LOG_PREFIX}-{timestamp}.log'
     prepare_calc_logger(logger,
                         file_name=log_name,
                         with_console=console_output)
-    logger.info(f"Starting new log: {log_name}\nTime of execution: "
+    logger.info(f'Starting new log: {log_name}\nTime of execution: '
                 + DateTimeFormat.LOG_CONTENTS.now())
-    logger.info(f"This is ViPErLEED version {__version__}\n")
+    logger.info(f'This is ViPErLEED version {__version__}\n')
 
-    tmp_manifest = ManifestFile(DEFAULT_SUPP, DEFAULT_OUT, log_name)
+    manifest = ManifestFile(DEFAULT_SUPP, DEFAULT_OUT, log_name)
     try:
-        rp = parameters.read()
-    except FileNotFoundError:
-        if not preset_params:
-            logger.error("No PARAMETERS file found, and no preset parameters "
-                         "passed. Execution will stop.")
-            cleanup(tmp_manifest)
-            return 2, None
-        rp = Rparams()
+        # Read input files and load user arguments
+        rpars, slab = _make_rpars_and_slab(manifest, preset_params, slab, home)
     except Exception:
-        logger.error("Exception while reading PARAMETERS file", exc_info=True)
-        cleanup(tmp_manifest)
+        cleanup(manifest)
         return 2, None
 
-    # Store the directory in which the calculation originally started
-    if home is None:
-        home = Path.cwd().parent
-    rp.paths.home = Path(home)
+    # Load runtime information in rpars
+    rpars.timestamp = timestamp
+    rpars.manifest = manifest
+    _set_tensorleed_source(rpars, source)
+    _set_system_name(rpars, system_name)
 
-    # check if this is going to be a domain search
-    domains = False
-    if "DOMAIN" in rp.readParams:
-        domains = True
-
-    if domains:  # no POSCAR in main folder for domain searches
-        slab = None
-    elif slab is None:
-        poscar_file = Path("POSCAR")
-        if not poscar_file.is_file():
-            logger.error("POSCAR not found. Stopping execution...")
-            cleanup(tmp_manifest)
-            return 2, None
-
-        logger.info("Reading structure from file POSCAR")
-        try:
-            slab = poscar.read(filename=poscar_file)
-        except Exception:
-            logger.error("Exception while reading POSCAR", exc_info=True)
-            cleanup(tmp_manifest)
-            return 2, None
-
-        if not slab.preprocessed:
-            logger.info("The POSCAR file will be processed and overwritten. "
-                        "Copying the original POSCAR to POSCAR_user...")
-            try:
-                shutil.copy2(poscar_file, "POSCAR_user")
-            except OSError:
-                logger.error("Failed to copy POSCAR to POSCAR_user. Stopping "
-                             "execution...")
-                cleanup(tmp_manifest)
-                return 2, None
-            tmp_manifest.add('POSCAR_user')
-    try:
-        # interpret the PARAMETERS file
-        parameters.interpret(rp, slab=slab, silent=False)
-    except (parameters.errors.ParameterNeedsSlabError,
-            parameters.errors.SuperfluousParameterError):
-        # Domains calculation is the only case in which slab is None
-        logger.error('Main PARAMETERS file contains an invalid parameter '
-                     'for a multi-domain calculation', exc_info=True)
-        cleanup(tmp_manifest)
-        return 2, None
-    except parameters.errors.ParameterError:
-        logger.error("Exception while reading PARAMETERS file", exc_info=True)
-        cleanup(tmp_manifest)
-        return 2, None
-
-    rp.timestamp = timestamp
-    rp.manifest = tmp_manifest
-
-    # Load parameter presets, overriding those in PARAMETERS
-    preset_params = preset_params or {}
-    try:
-        rp.update(preset_params)
-    except (ValueError, TypeError):
-        logger.warning(f"Error applying preset parameters: ", exc_info=True)
-
-    # set logging level
-    if 'LOG_LEVEL' in preset_params:
-        logger.info(f'Overriding log level to {rp.LOG_LEVEL}.')
-    logger.setLevel(rp.LOG_LEVEL)
-    logger.debug("PARAMETERS file was read successfully")
-
-    if not domains:
-        warn_if_slab_has_atoms_in_multiple_c_cells(slab, rp)
-        slab.full_update(rp)   # gets PARAMETERS data into slab
-        rp.fileLoaded["POSCAR"] = True
-
-    # set source directory
-    try:
-        rp.paths.tensorleed = get_tensorleed_path(source).resolve()
-    except (ValueError, FileNotFoundError) as exc:
-        logger.warning(f'{exc} This may cause errors.')
-        rp.paths.tensorleed = Path(source or '').resolve()
-
-    if system_name is None:
-        system_name = _get_parent_directory_name()
-    rp.systemName = system_name
-
-    # check if halting condition is already in effect:
-    if rp.halt >= rp.HALTING:
-        logger.info("Halting execution...")
-        cleanup(rp)
+    # Check if halting condition is already in effect
+    if rpars.halt >= rpars.HALTING:
+        logger.info('Halting execution...')
+        cleanup(rpars)
         return 0, None
 
-    rp.updateDerivedParams()
-    logger.info(f"ViPErLEED is using TensErLEED version {str(rp.TL_VERSION)}.")
+    rpars.updateDerivedParams()
+    logger.info(f'ViPErLEED is using TensErLEED version {rpars.TL_VERSION}.')
 
-    prerun_clean(rp, log_name)
-    preserve_original_inputs(rp)  # Store input files BEFORE any edit!
-    exit_code, state_recorder = section_loop(rp, slab)
+    prerun_clean(rpars, log_name)
+    preserve_original_inputs(rpars)  # Store inputs BEFORE any edit!
+    exit_code, state_recorder = section_loop(rpars, slab)
 
     # Finalize logging - if not done, will break unit testing
     close_all_handlers(logger)
@@ -229,10 +142,198 @@ def run_calc(
     return exit_code, state_recorder
 
 
-
 def _get_parent_directory_name():
     """Return the name of the directory above the current one."""
     _system_name = Path.cwd().resolve().parent.name
     logger.info('No system name specified. Using name of parent '
                 f'directory: {_system_name}')
     return _system_name
+
+
+def _make_rpars_and_slab(manifest, preset_params, slab, home):
+    """Return an Rparams and a SurfaceSlab.
+
+    Parameters
+    ----------
+    manifest : ManifestFile
+        The manifest file for this calculation.
+    preset_params : dict or None
+        Values of PARAMETERS to replace those read from file.
+    slab : SurfaceSlab or None
+        A user-given slab. If given, no POSCAR file is read from the
+        current directory.
+    home : pathlike or None
+        Path to the folder in which viperleed.calc was originally
+        executed, i.e., before moving to the work directory. If
+        not given or None, take the parent of the current directory.
+
+    Returns
+    -------
+    rpars : Rparams
+        The run parameters for this calculation, loaded with
+        `preset_params` and ready to be used.
+    slab : SurfaceSlab or None
+        The slab for this calculation. Read from POSCAR and
+        updated with the contents of `rpars`, unless this
+        is a multi-domain calculation. None in the latter
+        case.
+
+    Raises
+    ------
+    Exception
+        If reading PARAMETERS or, for a single-domain calculation,
+        POSCAR fails.
+    FileNotFoundError
+        If PARAMETERS is not found in the current directory.
+    FileNotFoundError
+        If POSCAR is not found in the current directory for a
+        single-domain calculation
+    OSError
+        If duplicating POSCAR to POSCAR_user fails.
+    ParameterError
+        If interpreting PARAMETERS fails.
+    TypeError
+        If a non-None `slab` is given in a multi-domain calculation.
+    """
+    rpars = _read_parameters_file(preset_params)
+
+    # Check if this is going to be a domain search
+    domains = 'DOMAIN' in rpars.readParams
+    if not domains and slab is None:
+        slab = _read_poscar_file(manifest)
+    elif domains and slab is not None:
+        # no POSCAR in main folder for domain searches
+        raise TypeError('Cannot give slab argument '
+                        'for a multi-domain calculation')
+
+    # Store the directory in which the calculation originally started.
+    # Must be done before interpreting PARAMETERS, as it is needed
+    # for DOMAIN.
+    if home is None:
+        home = Path.cwd().parent
+    rpars.paths.home = Path(home)
+
+    # Interpret the PARAMETERS file and load presets
+    _interpret_parameters(rpars, slab, preset_params or {})
+
+    if not domains:
+        warn_if_slab_has_atoms_in_multiple_c_cells(slab, rpars)
+        slab.full_update(rpars)   # gets PARAMETERS data into slab
+        rpars.fileLoaded['POSCAR'] = True
+    return rpars, slab
+
+
+def _interpret_parameters(rpars, slab, preset_params):
+    """Interpret PARAMETERS read from file and apply presets."""
+    try:
+        # interpret the PARAMETERS file
+        parameters.interpret(rpars, slab=slab, silent=False)
+    except (parameters.errors.ParameterNeedsSlabError,
+            parameters.errors.SuperfluousParameterError):
+        # Domains calculation is the only case in which slab is None
+        logger.error('Main PARAMETERS file contains an invalid parameter '
+                     'for a multi-domain calculation', exc_info=True)
+        raise
+    except parameters.errors.ParameterError:
+        logger.error('Exception while reading PARAMETERS file', exc_info=True)
+        raise
+
+    # Load parameter presets, overriding those in PARAMETERS
+    try:
+        rpars.update(preset_params)
+    except (ValueError, TypeError):
+        logger.warning('Error applying preset parameters: ', exc_info=True)
+
+    _set_log_level(rpars, preset_params)
+    logger.debug('PARAMETERS file was read successfully')
+
+
+def _read_parameters_file(preset_params):
+    """Return an Rparams read from PARAMETERS in the current directory."""
+    try:
+        return parameters.read()
+    except FileNotFoundError:
+        if preset_params:
+            return Rparams()
+        logger.error('No PARAMETERS file found, and no preset parameters '
+                     'passed. Execution will stop.')
+        raise
+    except Exception:
+        logger.error('Exception while reading PARAMETERS file', exc_info=True)
+        raise
+
+
+def _read_poscar_file(manifest):
+    """Return a SurfaceSlab read from POSCAR in the current directory.
+
+    If the POSCAR file in the current directory has not been used
+    for a viperleed.calc execution before, it is duplicated as
+    POSCAR_user.
+
+    Parameters
+    ----------
+    manifest : ManifestFile
+        The manifest file used for this calculation. Used to retain
+        information on whether POSCAR_user was created.
+
+    Returns
+    -------
+    slab : SurfaceSlab
+        Slab read from POSCAR.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no POSCAR file is found in the current directory.
+    OSError
+        If duplicating POSCAR to POSCAR_user fails.
+    Exception
+        If reading POSCAR fails.
+    """
+    poscar_file = Path('POSCAR')
+    logger.info('Reading structure from file POSCAR')
+    try:
+        slab = poscar.read(filename=poscar_file)
+    except FileNotFoundError:
+        logger.error('POSCAR not found. Stopping execution...')
+        raise
+    except Exception:
+        logger.error('Exception while reading POSCAR', exc_info=True)
+        raise
+
+    if not slab.preprocessed:
+        logger.info('The POSCAR file will be processed and overwritten. '
+                    'Copying the original POSCAR to POSCAR_user...')
+        try:
+            shutil.copy2(poscar_file, 'POSCAR_user')
+        except OSError:
+            logger.error('Failed to copy POSCAR to POSCAR_user. Stopping '
+                         'execution...')
+            raise
+        manifest.add('POSCAR_user')
+    return slab
+
+
+def _set_log_level(rpars, preset_params):
+    """Assign a (user-defined) log level to the current logger."""
+    # pylint: disable-next=magic-value-comparison
+    if 'LOG_LEVEL' in preset_params:
+        logger.info(f'Overriding log level to {rpars.LOG_LEVEL}.')
+    logger.setLevel(rpars.LOG_LEVEL)
+
+
+def _set_tensorleed_source(rpars, source):
+    """Set `source` as the directory for tensor-LEED files/executables."""
+    try:
+        tensorleed = get_tensorleed_path(source).resolve()
+    except (ValueError, FileNotFoundError) as exc:
+        logger.warning(f'{exc} This may cause errors.')
+        tensorleed = Path(source or '').resolve()
+    rpars.paths.tensorleed = tensorleed
+
+
+def _set_system_name(rpars, system_name):
+    """Assign a system name to rpars from `system_name` or the CWD."""
+    if system_name is None:
+        system_name = _get_parent_directory_name()
+    rpars.systemName = system_name

--- a/src/viperleed/calc/run.py
+++ b/src/viperleed/calc/run.py
@@ -135,17 +135,18 @@ def run_calc(
     preserve_original_inputs(rpars)  # Store inputs BEFORE any edit!
     exit_code, state_recorder = section_loop(rpars, slab)
 
-    # Finalize logging - if not done, will break unit testing
-    close_all_handlers(logger)
-    logging.shutdown()
-
+    # Prevent other sub-loggers from producing more
+    # messages for the main log file of viperleed calc.
+    close_all_handlers(LOGGER)
     return exit_code, state_recorder
 
 
 def _finalize_on_early_exit(rpars_or_manifest):
     """Finish a calc execution before entering the `section_loop`."""
     cleanup(rpars_or_manifest)
-    close_all_handlers(logger)
+    # Prevent other sub-loggers from producing more
+    # messages for the main log file of viperleed calc.
+    close_all_handlers(LOGGER)
 
 
 def _get_parent_directory_name():

--- a/src/viperleed/calc/sections/cleanup.py
+++ b/src/viperleed/calc/sections/cleanup.py
@@ -31,7 +31,6 @@ from viperleed.calc.constants import LOG_PREFIX
 from viperleed.calc.constants import ORIGINAL_INPUTS_DIR_NAME
 from viperleed.calc.lib.base import copytree_exists_ok
 from viperleed.calc.lib.context import execute_in_dir
-from viperleed.calc.lib.log_utils import close_all_handlers
 from viperleed.calc.lib.time_utils import DateTimeFormat
 from viperleed.calc.sections.calc_section import ALL_INPUT_FILES
 from viperleed.calc.sections.calc_section import EXPBEAMS_NAMES
@@ -588,9 +587,6 @@ def cleanup(rpars_or_manifest):
       the bookkeeper and a checklist of items for user are also
       logged.
 
-    The logging module is fully shut down after this function
-    is executed, and should not be used any longer.
-
     Parameters
     ----------
     rpars_or_manifest : Rparams or ManifestFile
@@ -624,10 +620,6 @@ def cleanup(rpars_or_manifest):
     _organize_all_work_directories(rpars)
     _write_manifest_file(rpars)
     _write_final_log_messages(rpars)
-
-    # Shut down logger
-    close_all_handlers(_LOGGER)
-    logging.shutdown()
 
 
 def preserve_original_inputs(rpars):

--- a/src/viperleed/utilities/poscar/attach_bulk.py
+++ b/src/viperleed/utilities/poscar/attach_bulk.py
@@ -19,6 +19,7 @@ import logging
 import numpy as np
 
 from viperleed.calc.files import poscar
+from viperleed.calc.lib.log_utils import close_all_handlers
 from viperleed.calc.lib.time_utils import DateTimeFormat
 from viperleed.calc.lib.time_utils import ExecutionTimer
 from viperleed.cli_base import ViPErLEEDCLI
@@ -47,7 +48,7 @@ class AttachBulkCLI(ViPErLEEDCLI, cli_name='attach_bulk'):
         except KeyboardInterrupt:
             return 1
         finally:
-            _tear_down_logger()
+            close_all_handlers(logging.getLogger())
 
     @staticmethod
     def _call_impl():
@@ -165,12 +166,6 @@ def _set_up_logger(logname):
     logging.basicConfig(level=logging.DEBUG, filename=logname,
                         filemode='w', format=_LOG_FORMAT)
     logging.getLogger().addHandler(_CONSOLE_HANDLER)
-
-
-def _tear_down_logger():
-    """Remove handlers and shutdown the logger."""
-    logging.getLogger().removeHandler(_CONSOLE_HANDLER)
-    logging.shutdown()
 
 
 if __name__ == '__main__':

--- a/tests/calc/bookkeeper/bookkeeper/test_run_with_calc.py
+++ b/tests/calc/bookkeeper/bookkeeper/test_run_with_calc.py
@@ -53,8 +53,9 @@ class TestBookkeeperDuringCalc(_TestBookkeeperRunBase):
         """Check results when calc fails because of missing inputs."""
         cli = ViPErLEEDCalcCLI()
         with execute_in_dir(tmp_path):
-            calc_error = cli([])
+            calc_error = cli(['--delete-workdir'])
             assert calc_error
             bookkeeper = Bookkeeper()
             exit_code = bookkeeper.run('fix')
             assert exit_code is BookkeeperExitCode.NOTHING_TO_DO
+        assert not (tmp_path/'work').exists()

--- a/tests/calc/sections/cleanup/test_cleanup.py
+++ b/tests/calc/sections/cleanup/test_cleanup.py
@@ -182,8 +182,6 @@ class TestWriteFinalLogMessages:
     def check_has_records(caplog, records):
         """Ensure caplog has only certain records."""
         logged = tuple(r.getMessage() for r in caplog.records)
-        print(logged)
-        print(records)
         assert len(logged) == len(records)
         for log, expect in zip(logged, records):
             if isinstance(expect, str):

--- a/tests/calc/sections/cleanup/test_cleanup.py
+++ b/tests/calc/sections/cleanup/test_cleanup.py
@@ -37,14 +37,16 @@ class TestCleanup:
         '_organize_all_work_directories',
         '_write_manifest_file',
         '_write_final_log_messages',
-        'close_all_handlers',
+        )
+    not_called = (
         'logging.shutdown',
         )
 
     @fixture(name='mock_implementation')
     def fixture_mock_implementation(self, mocker):
         """Replace implementation details of cleanup with mocks."""
-        return {f: mocker.patch(f'{_MODULE}.{f}') for f in self.mocked}
+        return {f: mocker.patch(f'{_MODULE}.{f}')
+                for f in (*self.mocked, *self.not_called)}
 
     @fixture(name='manifest')
     def mock_manifest(self):
@@ -64,15 +66,13 @@ class TestCleanup:
             '_organize_all_work_directories': fake_rpars,
             '_write_manifest_file': fake_rpars,
             '_write_final_log_messages': fake_rpars,
-            'close_all_handlers': None,
-            'logging.shutdown': None,
             }
         for func, arg in calls.items():
             mock = mock_implementation[func]
-            if arg is None:
-                mock.assert_called_once()
-            else:
-                mock.assert_called_once_with(arg)
+            mock.assert_called_once_with(arg)
+        for mock_name in self.not_called:
+            mock = mock_implementation[mock_name]
+            mock.assert_not_called()
 
     @parametrize(mock_name=mocked)
     def test_raises(self, mock_name, rpars, mock_implementation):
@@ -90,15 +90,13 @@ class TestCleanup:
             '_organize_all_work_directories': rpars,
             '_write_manifest_file': rpars,
             '_write_final_log_messages': rpars,
-            'close_all_handlers': None,
-            'logging.shutdown': None,
             }
         for func, arg in calls.items():
             mock = mock_implementation[func]
-            if arg is None:
-                mock.assert_called_once()
-            else:
-                mock.assert_called_once_with(arg)
+            mock.assert_called_once_with(arg)
+        for mock_name in self.not_called:
+            mock = mock_implementation[mock_name]
+            mock.assert_not_called()
 
     @parametrize(arg=(None, 'str', set(), {}, tuple()))
     def test_typeerror(self, arg):

--- a/tests/calc/test_run.py
+++ b/tests/calc/test_run.py
@@ -112,9 +112,11 @@ class TestRunCalc:
             'preserve': mocker.call(rpars),
             'section': mocker.call(rpars, slab),
             'handlers': mocker.call(mocks['logger']),
-            'shutdown': mocker.call(),
             }
-        not_called = ('finalize',)  # Only in error cases
+        not_called = (
+            'finalize',  # Only in error cases
+            'shutdown',
+            )
 
         result = run_calc(**kwargs)
         assert result == mocks['section'].return_value

--- a/tests/calc/test_run.py
+++ b/tests/calc/test_run.py
@@ -573,7 +573,7 @@ class TestSetTensorleedSource:
         assert not caplog.text
 
     _fails = {
-        None: Path.cwd(),
+        None: Path(),
         'some/source/path': Path('some/source/path'),
         }
 
@@ -586,7 +586,7 @@ class TestSetTensorleedSource:
         rpars = mocks['rpars']
         mocks['get'].side_effect = exc
         _set_tensorleed_source(rpars, src)
-        assert rpars.paths.tensorleed == expect
+        assert rpars.paths.tensorleed == expect.resolve()
         assert caplog.text
 
 

--- a/tests/calc/test_run.py
+++ b/tests/calc/test_run.py
@@ -56,7 +56,7 @@ class TestRunCalc:
         mocks = {
             'umask': mocker.patch('os.umask'),
             'now': mock_now,
-            'logger': mocker.patch(f'{_MODULE}.logger'),
+            'logger': mocker.patch(f'{_MODULE}.LOGGER'),
             'prepare_log': mocker.patch(f'{_MODULE}.prepare_calc_logger'),
             'manifest': mocker.patch(f'{_MODULE}.ManifestFile',
                                      return_value=mock_manifest),
@@ -210,7 +210,7 @@ class TestFinalizeOnEarlyExit:
     def fixture_mock_implementation(self, mocker):
         """Replace implementation details with mocks."""
         return {
-            'logger': mocker.patch(f'{_MODULE}.logger'),
+            'logger': mocker.patch(f'{_MODULE}.LOGGER'),
             'cleanup': mocker.patch(f'{_MODULE}.cleanup'),
             'handlers': mocker.patch(f'{_MODULE}.close_all_handlers'),
             }
@@ -522,7 +522,7 @@ class TestSetLogLevel:
         """Replace implementation details with mocks."""
         rpars = Rparams()
         rpars.LOG_LEVEL = 37
-        mock_logger = mocker.patch(f'{_MODULE}.logger')
+        mock_logger = mocker.patch(f'{_MODULE}.LOGGER')
         return rpars, mock_logger
 
     def test_preset(self, mocks):

--- a/tests/calc/test_run.py
+++ b/tests/calc/test_run.py
@@ -1,0 +1,582 @@
+"""Tests for module run of viperleed.calc."""
+
+__authors__ = (
+    'Michele Riva (@michele-riva)',
+    )
+__copyright__ = 'Copyright (c) 2019-2025 ViPErLEED developers'
+__created__ = '2025-03-05'
+__license__ = 'GPLv3+'
+
+import logging
+from pathlib import Path
+
+import pytest
+from pytest_cases import fixture
+from pytest_cases import parametrize
+
+from viperleed.calc.files import parameters
+from viperleed.calc.classes.rparams.rparams import Rparams
+from viperleed.calc.run import _get_parent_directory_name
+from viperleed.calc.run import _make_rpars_and_slab
+from viperleed.calc.run import _interpret_parameters
+from viperleed.calc.run import _read_parameters_file
+from viperleed.calc.run import _read_poscar_file
+from viperleed.calc.run import _set_log_level
+from viperleed.calc.run import _set_tensorleed_source
+from viperleed.calc.run import _set_system_name
+from viperleed.calc.run import run_calc
+
+_MODULE = 'viperleed.calc.run'
+
+
+class TestRunCalc:
+    """Tests for the run_calc function."""
+
+    @staticmethod
+    def check_calls(mocks, expected_calls, not_called, n_log_msgs):
+        """Ensure mocks have been called or not."""
+        for mock_name, call in expected_calls.items():
+            assert mocks[mock_name].mock_calls == [call]
+        for mock_name in not_called:
+            mocks[mock_name].assert_not_called()
+        assert len(mocks['logger'].info.mock_calls) == n_log_msgs
+        assert len(mocks['logger'].method_calls) == n_log_msgs
+
+    @fixture(name='mocks')
+    def fixture_mock_implementation(self, mocker):
+        """Replace implementation details with mocks."""
+        rpars = Rparams()
+        slab = mocker.MagicMock()
+        mock_manifest = mocker.MagicMock()
+        mock_now = mocker.MagicMock(return_value='some_timestamp')
+        mock_fmt = mocker.patch(f'{_MODULE}.DateTimeFormat')
+        mock_fmt.FILE_SUFFIX.now = mock_now
+        mock_fmt.LOG_CONTENTS.now = mock_now
+        mocks = {
+            'umask': mocker.patch('os.umask'),
+            'now': mock_now,
+            'logger': mocker.patch(f'{_MODULE}.logger'),
+            'prepare_log': mocker.patch(f'{_MODULE}.prepare_calc_logger'),
+            'manifest': mocker.patch(f'{_MODULE}.ManifestFile',
+                                     return_value=mock_manifest),
+            'make_rp_sl': mocker.patch(f'{_MODULE}._make_rpars_and_slab',
+                                       return_value=(rpars, slab)),
+            'cleanup': mocker.patch(f'{_MODULE}.cleanup'),
+            'set_src': mocker.patch(f'{_MODULE}._set_tensorleed_source'),
+            'set_name': mocker.patch(f'{_MODULE}._set_system_name'),
+            'find_tl_version': mocker.patch.object(rpars,
+                                                   'updateDerivedParams'),
+            'prerun': mocker.patch(f'{_MODULE}.prerun_clean'),
+            'preserve': mocker.patch(f'{_MODULE}.preserve_original_inputs'),
+            'section': mocker.patch(f'{_MODULE}.section_loop',
+                                    return_value=(0, 'recorder')),
+            'handlers': mocker.patch(f'{_MODULE}.close_all_handlers'),
+            'shutdown': mocker.patch(f'{_MODULE}.logging.shutdown'),
+            }
+        return mocks
+
+    _user_args = (
+        {'system_name': 'some name'},
+        {'console_output': 'log to console'},
+        {'slab': 'user-given slab'},
+        {'preset_params': 'some parameter presets'},
+        {'source': 'path to tensorleed'},
+        {'home': 'where calc started'},
+        )
+
+    @parametrize(kwargs=_user_args)
+    def test_success_calls(self, kwargs, mocks, mocker):
+        """Check the expected calls for a successful run."""
+        rpars, slab = mocks['make_rp_sl'].return_value
+        timestamp = mocks['now']()
+        log_name = f'viperleed-calc-{timestamp}.log'
+        expect_calls = {
+            'umask': mocker.call(0),
+            'prepare_log': mocker.call(
+                mocks['logger'],
+                file_name=log_name,
+                with_console=kwargs.get('console_output', True),
+                ),
+            'manifest': mocker.call('SUPP', 'OUT', log_name),
+            'make_rp_sl': mocker.call(
+                mocks['manifest'].return_value,
+                kwargs.get('preset_params'),
+                kwargs.get('slab'),
+                kwargs.get('home'),
+                ),
+            'set_src': mocker.call(rpars, kwargs.get('source')),
+            'set_name': mocker.call(rpars, kwargs.get('system_name')),
+            'find_tl_version': mocker.call(),
+            'prerun': mocker.call(rpars, log_name),
+            'preserve': mocker.call(rpars),
+            'section': mocker.call(rpars, slab),
+            'handlers': mocker.call(mocks['logger']),
+            'shutdown': mocker.call(),
+            }
+        not_called = ('cleanup',)  # Only in error cases
+
+        result = run_calc(**kwargs)
+        assert result == mocks['section'].return_value
+        assert rpars.timestamp == timestamp
+        assert rpars.manifest is mocks['manifest'].return_value
+
+        self.check_calls(mocks, expect_calls, not_called, n_log_msgs=3)
+
+    _raises = (
+        Exception,
+        FileNotFoundError,
+        OSError,
+        parameters.errors.ParameterError,
+        TypeError,
+        )
+
+    @parametrize(exc=_raises)
+    def test_read_inputs_fails(self, exc, mocks, mocker):
+        """Check behavior when reading inputs fails."""
+        mocks['make_rp_sl'].side_effect = exc
+        exit_code, states = run_calc()
+        assert exit_code
+        assert not states
+
+        timestamp = mocks['now']()
+        log_name = f'viperleed-calc-{timestamp}.log'
+        expect_calls = {
+            'umask': mocker.call(0),
+            'prepare_log': mocker.call(mocks['logger'],
+                                       file_name=log_name,
+                                       with_console=True),
+            'manifest': mocker.call('SUPP', 'OUT', log_name),
+            'make_rp_sl': mocker.call(mocks['manifest'].return_value,
+                                      None,   # preset_params
+                                      None,   # slab
+                                      None),  # home
+            'cleanup': mocker.call(mocks['manifest'].return_value),
+            }
+        not_called = (
+            'set_src',
+            'set_name',
+            'find_tl_version',
+            'prerun',
+            'preserve',
+            'section',
+            'handlers',
+            'shutdown',
+            )
+        self.check_calls(mocks, expect_calls, not_called, n_log_msgs=2)
+
+    def test_halt_active(self, mocks, mocker):
+        """Check early exit if halting is in effect."""
+        rpars, _ = mocks['make_rp_sl'].return_value
+        timestamp = mocks['now']()
+        rpars.halt = 2  # Should stop right away with default HALTING
+
+        exit_code, states = run_calc()
+        assert not exit_code
+        assert not states
+        assert rpars.timestamp == timestamp
+        assert rpars.manifest is mocks['manifest'].return_value
+
+        log_name = f'viperleed-calc-{timestamp}.log'
+        expect_calls = {
+            'umask': mocker.call(0),
+            'prepare_log': mocker.call(mocks['logger'],
+                                       file_name=log_name,
+                                       with_console=True),
+            'manifest': mocker.call('SUPP', 'OUT', log_name),
+            'make_rp_sl': mocker.call(mocks['manifest'].return_value,
+                                      None,   # preset_params
+                                      None,   # slab
+                                      None),  # home
+            'set_src': mocker.call(rpars, None),
+            'set_name': mocker.call(rpars, None),
+            'cleanup': mocker.call(rpars),
+            }
+        not_called = (
+            'find_tl_version',
+            'prerun',
+            'preserve',
+            'section',
+            'handlers',
+            'shutdown',
+            )
+        self.check_calls(mocks, expect_calls, not_called, n_log_msgs=3)
+
+
+def test_get_parent_directory_name(mocker, caplog):
+    """Test correct result of the _get_parent_directory_name helper."""
+    caplog.set_level(5)
+    fake_cwd = Path('/home/user/project')
+    mocker.patch('pathlib.Path.cwd', return_value=fake_cwd)
+    expect_name = 'user'
+    assert _get_parent_directory_name() == expect_name
+    assert expect_name in caplog.text
+
+
+class TestMakeRparsAndSlab:
+    """Tests for the _make_rpars_and_slab helper."""
+
+    @fixture(name='mocks')
+    def fixture_mock_implementation(self, mocker):
+        """Replace implementation details with mocks."""
+        mock_slab = mocker.MagicMock()
+        mock_rpars = Rparams()
+        return {
+            'rpars': mock_rpars,
+            'slab': mock_slab,
+            'read_param': mocker.patch(f'{_MODULE}._read_parameters_file',
+                                       return_value=mock_rpars),
+            'read_poscar': mocker.patch(f'{_MODULE}._read_poscar_file',
+                                        return_value=mock_slab),
+            'interpret': mocker.patch(f'{_MODULE}._interpret_parameters'),
+            'warn_slab': mocker.patch(
+                f'{_MODULE}.warn_if_slab_has_atoms_in_multiple_c_cells',
+                ),
+            }
+
+    def test_domains(self, mocks):
+        """Check correct outcome for a multi-domain case."""
+        manifest = set()
+        presets = None
+        mocks['rpars'].readParams['DOMAIN'] = 'some domain'
+        rpars, slab = _make_rpars_and_slab(manifest,
+                                           presets,
+                                           slab=None,
+                                           home='here')
+        assert rpars is mocks['rpars']
+        assert slab is None
+        assert not rpars.fileLoaded['POSCAR']
+        assert rpars.paths.home == Path('here')
+        args = {
+            'read_param': (presets,),
+            'interpret': (rpars, slab, {}),
+            }
+        for mock_name, mock_args in args.items():
+            mocks[mock_name].assert_called_once_with(*mock_args)
+        mocks['read_poscar'].assert_not_called()
+        mocks['warn_slab'].assert_not_called()
+        mocks['slab'].full_update.assert_not_called()
+
+    def test_domains_raises(self, mocks):
+        """Check correct outcome for a multi-domain case."""
+        manifest = set()
+        presets = None
+        mocks['rpars'].readParams['DOMAIN'] = 'some domain'
+        with pytest.raises(TypeError):
+            _make_rpars_and_slab(manifest, presets, slab='a slab', home=None)
+
+        mocks['read_param'].assert_called_once_with(presets)
+        not_called = 'interpret', 'read_poscar', 'warn_slab'
+        for mock_name in not_called:
+            mocks[mock_name].assert_not_called()
+
+    _raises = (
+        ('read_param', Exception),
+        ('read_param', FileNotFoundError),
+        ('read_poscar', Exception),
+        ('read_poscar', FileNotFoundError),
+        ('read_poscar', OSError),
+        ('interpret', parameters.errors.ParameterError),
+        )
+
+    @parametrize('mock_name,exc', _raises)
+    def test_implementation_raises(self, mock_name, exc, mocks):
+        """Check that exceptions raised by the implementation bubble out."""
+        mocks[mock_name].side_effect = exc('test exc')
+        with pytest.raises(exc, match='test exc'):
+            _make_rpars_and_slab({}, None, None, None)
+
+    def test_one_domain_no_slab(self, mocks):
+        """Check correct outcome for a single domain and no slab given."""
+        manifest = set()
+        presets = {'some_preset': 1}
+        rpars, slab = _make_rpars_and_slab(manifest,
+                                           presets,
+                                           slab=None,
+                                           home=None)
+        assert rpars is mocks['rpars']
+        assert slab is mocks['slab']
+        assert rpars.fileLoaded['POSCAR']
+        assert rpars.paths.home
+        args = {
+            'read_param': (presets,),
+            'read_poscar': (manifest,),
+            'interpret': (rpars, slab, presets),
+            'warn_slab': (slab, rpars),
+            }
+        for mock_name, mock_args in args.items():
+            mocks[mock_name].assert_called_once_with(*mock_args)
+        mocks['slab'].full_update.assert_called_once_with(rpars)
+
+    def test_one_domain_with_slab(self, mocks, mocker):
+        """Check correct outcome for a single domain and a user-given slab."""
+        manifest = set()
+        presets = {'some_preset': 1}
+        slab_arg = mocker.MagicMock()
+        rpars, slab = _make_rpars_and_slab(manifest,
+                                           presets,
+                                           slab=slab_arg,
+                                           home=None)
+        assert slab is slab_arg
+        assert rpars.fileLoaded['POSCAR']
+        assert rpars.paths.home
+        args = {
+            'read_param': (presets,),
+            'interpret': (rpars, slab, presets),
+            'warn_slab': (slab, rpars),
+            }
+        for mock_name, mock_args in args.items():
+            mocks[mock_name].assert_called_once_with(*mock_args)
+        mocks['read_poscar'].assert_not_called()
+        slab.full_update.assert_called_once_with(rpars)
+
+
+class TestInterpretParameters:
+    """Tests for the _interpret_parameters helper."""
+
+    @fixture(name='mock_implementation')
+    def fixture_mock_implementation(self, mocker):
+        """Replace implementation details with mocks."""
+        mock_slab = mocker.MagicMock()
+        mock_rpars = Rparams()
+        mock_presets = {'LOG_LEVEL': 'DEBUG'}
+        mocks = {
+            'interpret': mocker.patch(f'{_MODULE}.parameters.interpret'),
+            'set_log': mocker.patch(f'{_MODULE}._set_log_level'),
+            'update': mocker.patch.object(mock_rpars, 'update'),
+            }
+        return mock_rpars, mock_slab, mock_presets, mocks
+
+    def test_interpret_and_update(self, mock_implementation, mocker, caplog):
+        """Check correct interpretation and update of parameters."""
+        caplog.set_level(logging.INFO)
+        rpars, slab, presets, mocks = mock_implementation
+        _interpret_parameters(rpars, slab, presets)
+        calls = {
+            'interpret': mocker.call(rpars, slab=slab, silent=False),
+            'update': mocker.call(presets),
+            'set_log': mocker.call(rpars, presets),
+            }
+        for mock_name, expect_call in calls.items():
+            assert mocks[mock_name].mock_calls == [expect_call]
+        assert not caplog.text
+
+    interpret_raises = (
+        parameters.errors.ParameterNeedsSlabError,
+        parameters.errors.SuperfluousParameterError,
+        parameters.errors.ParameterError,
+        )
+
+    @parametrize(exc=interpret_raises)
+    def test_interpret_raises(self, exc, mock_implementation, caplog):
+        """Check bubble-out of exceptions in implementation details."""
+        *args, mocks = mock_implementation
+        mocks['interpret'].side_effect = exc('test exc')
+        with pytest.raises(exc, match='test exc'):
+            _interpret_parameters(*args)
+        assert caplog.text
+
+    @parametrize(exc=(ValueError, TypeError))
+    def test_apply_presets_fails(self, exc, mock_implementation, caplog):
+        """Check that logs are emitted when applying presets fails."""
+        *args, mocks = mock_implementation
+        mocks['update'].side_effect = exc
+        _interpret_parameters(*args)  # No exception here
+        assert caplog.text
+
+
+class TestReadParametersFile:
+    """Tests for the _read_parameters_file helper."""
+
+    @fixture(name='mocks')
+    def fixture_mock(self, mocker):
+        """Replace implementation details with mocks."""
+        mock_rpars = Rparams()
+        mock_read = mocker.patch(f'{_MODULE}.parameters.read',
+                                 return_value=mock_rpars)
+        return mock_rpars, mock_read
+
+    def test_reads_existing_parameters(self, mocks, caplog):
+        """Check correct result when PARAMETERS is found."""
+        caplog.set_level(5)  # < DEBUG
+        rpars, mock_read = mocks
+        result = _read_parameters_file('some unused preset')
+        mock_read.assert_called_once()
+        assert result is rpars
+        assert not caplog.text
+
+    def test_not_found_no_presets(self, mocks, caplog):
+        """Check complaints with neither PARAMETERS nor presets."""
+        _, mock_read = mocks
+        mock_read.side_effect = FileNotFoundError
+        with pytest.raises(FileNotFoundError):
+            _read_parameters_file(None)
+        assert caplog.text
+
+    def test_not_found_with_presets(self, mocks, caplog):
+        """Check no complaints with no PARAMETERS but user presets."""
+        caplog.set_level(5)  # < DEBUG
+        _, mock_read = mocks
+        mock_read.side_effect = FileNotFoundError
+        result = _read_parameters_file('some preset')
+        assert isinstance(result, Rparams)
+        assert not caplog.text
+
+    def test_read_fails(self, mocks, caplog):
+        """Check exceptions while reading PARAMETERS bubble out."""
+        _, mock_read = mocks
+        mock_read.side_effect = Exception('test exc')
+        with pytest.raises(Exception, match='test exc'):
+            _read_parameters_file(None)
+        assert caplog.text
+
+
+class TestReadPoscarFile:
+    """Tests for the _read_poscar_file helper."""
+
+    @fixture(name='mocks')
+    def fixture_mock_implementation(self, mocker):
+        """Replace implementation details with mocks."""
+        mock_slab = mocker.MagicMock()
+        return {
+            'slab': mock_slab,
+            'read': mocker.patch(f'{_MODULE}.poscar.read',
+                                 return_value=mock_slab),
+            'copy': mocker.patch('shutil.copy2'),
+            }
+
+    def test_success(self, mocks, caplog):
+        """Test successful reading of a POSCAR file."""
+        caplog.set_level(logging.INFO)
+        manifest = set()
+        mocks['slab'].preprocessed = True
+        slab = _read_poscar_file(manifest)
+        expect_log = 'Reading structure'
+
+        assert slab is mocks['slab']
+        mocks['read'].assert_called_once_with(filename=Path('POSCAR'))
+        mocks['copy'].assert_not_called()
+        assert not manifest
+        assert expect_log in caplog.text
+
+    def test_poscar_user(self, mocks, caplog):
+        """Test successful reading of a "fresh" POSCAR file."""
+        caplog.set_level(logging.INFO)
+        manifest = set()
+        mocks['slab'].preprocessed = False
+        slab = _read_poscar_file(manifest)
+        expect_log = 'Reading structure'
+
+        assert slab is mocks['slab']
+        mocks['read'].assert_called_once_with(filename=Path('POSCAR'))
+        mocks['copy'].assert_called_once_with(Path('POSCAR'), 'POSCAR_user')
+        assert manifest
+        assert expect_log in caplog.text
+
+    _raises = (
+        ('read', FileNotFoundError),
+        ('read', Exception),
+        ('copy', OSError),
+        )
+
+    @parametrize('mock_name,exc', _raises)
+    def test_raises(self, mock_name, exc, mocks, caplog):
+        """Check complaints when the implementation raises exceptions."""
+        caplog.set_level(logging.ERROR)
+        mocks[mock_name].side_effect = exc('test exc')
+        mocks['slab'].preprocessed = False
+        with pytest.raises(exc, match='test exc'):
+            _read_poscar_file(None)
+        assert caplog.text
+
+
+class TestSetLogLevel:
+    """Tests for the _set_log_level helper."""
+
+    @fixture(name='mocks')
+    def fixture_mock_implementation(self, mocker):
+        """Replace implementation details with mocks."""
+        rpars = Rparams()
+        rpars.LOG_LEVEL = 37
+        mock_logger = mocker.patch(f'{_MODULE}.logger')
+        return rpars, mock_logger
+
+    def test_preset(self, mocks):
+        """Test setting log level from preset parameters."""
+        rpars, mock_logger = mocks
+        presets = {'LOG_LEVEL'}
+        _set_log_level(rpars, presets)
+        expect_log = 'Overriding log level to 37.'
+        mock_logger.setLevel.assert_called_once_with(rpars.LOG_LEVEL)
+        mock_logger.info.assert_called_once_with(expect_log)
+        n_log_calls = 2  # setLevel and info
+        assert len(mock_logger.method_calls) == n_log_calls
+
+    def test_no_preset(self, mocks):
+        """Test setting log level without presets."""
+        rpars, mock_logger = mocks
+        _set_log_level(rpars, {})
+        mock_logger.setLevel.assert_called_once_with(rpars.LOG_LEVEL)
+        assert len(mock_logger.method_calls) == 1  # only setLevel
+
+
+class TestSetTensorleedSource:
+    """Tests for the _set_tensorleed_source helper."""
+
+    @fixture(name='mocks')
+    def fixture_mock_implementation(self, mocker):
+        """Replace internal implementation details with mocks."""
+        mock_source = Path('/some/path/to/tensorleed')
+        mock_rpars = Rparams()
+        mock_get = mocker.patch(f'{_MODULE}.get_tensorleed_path',
+                                return_value=mock_source)
+        return {
+            'src': mock_source.resolve(),
+            'rpars': mock_rpars,
+            'get': mock_get,
+            }
+
+    def test_success(self, mocks, caplog):
+        """Check the successful setting of a source path."""
+        caplog.set_level(5)  # < DEBUG
+        rpars = mocks['rpars']
+        src = 'some/source/path'
+        _set_tensorleed_source(rpars, src)
+        mocks['get'].assert_called_once_with(src)
+        assert rpars.paths.tensorleed == mocks['src']
+        assert not caplog.text
+
+    _fails = {
+        None: Path.cwd(),
+        'some/source/path': Path('some/source/path'),
+        }
+
+    @parametrize(exc=(ValueError, FileNotFoundError))
+    @parametrize('src,expect', _fails.items())
+    # pylint: disable-next=too-many-arguments  # 2/6 fixtures
+    def test_get_fails(self, exc, src, expect, mocks, caplog):
+        """Check the successful setting of a source path."""
+        caplog.set_level(logging.WARNING)
+        rpars = mocks['rpars']
+        mocks['get'].side_effect = exc
+        _set_tensorleed_source(rpars, src)
+        assert rpars.paths.tensorleed == expect
+        assert caplog.text
+
+
+class TestSetSystemName:
+    """Tests for the _set_system_name helper."""
+
+    def test_user_given(self, mocker):
+        """Test setting a system name when explicitly provided."""
+        rpars, explicit = (mocker.MagicMock() for _ in range(2))
+        _set_system_name(rpars, explicit)
+        assert rpars.systemName is explicit
+
+    def test_from_parent_directory(self, mocker):
+        """Test setting system name from the parent directory."""
+        rpars, parent = (mocker.MagicMock() for _ in range(2))
+        mock_get_parent = mocker.patch(f'{_MODULE}._get_parent_directory_name',
+                                       return_value=parent)
+        _set_system_name(rpars, None)
+        assert rpars.systemName is parent
+        mock_get_parent.assert_called_once()

--- a/tests/calc/utilities/poscar/test_sort_by_z.py
+++ b/tests/calc/utilities/poscar/test_sort_by_z.py
@@ -82,5 +82,4 @@ def slab_is_sorted(slab, reversed=False):
 
     not_same_el = np.array(at1.el != at2.el
                       for at1, at2 in zip(slab.atlist[:-1], slab.atlist[1:]))
-    print(z_order, not_same_el)
     return np.all(np.logical_or(z_order, not_same_el))


### PR DESCRIPTION
In the implementation of `calc`+`bookkeeper` before this PR, log messages emitted by the latter would end up in the main `calc` log file if `run_calc` exits before calling `section_loop`. That's because we did not close handlers associated with the `calc` logger under these conditions. Since `bookkeeper` is a sub-package of `calc`, its logger is a "child" of the `calc` one.

This PR does:
- refactor `calc.run` into helper functions to improve readability
- add comprehensive tests for 100% coverage of the module
- close handlers of the calc logger also upon early exit in case of either error or a halting condition.