### PR TITLE
Backward-compatible shutil.move

### DIFF
--- a/src/viperleed/calc/cli.py
+++ b/src/viperleed/calc/cli.py
@@ -23,7 +23,7 @@ from viperleed.calc import DEFAULT_WORK
 from viperleed.calc import DEFAULT_WORK_HISTORY
 from viperleed.calc.bookkeeper import BookkeeperMode
 from viperleed.calc.bookkeeper import bookkeeper
-from viperleed.calc.lib.base import copytree_exists_ok
+from viperleed.calc.lib.fs_util import copytree_exists_ok
 from viperleed.calc.lib.leedbase import getMaxTensorIndex
 from viperleed.calc.run import run_calc
 from viperleed.calc.sections.calc_section import ALL_INPUT_FILES

--- a/src/viperleed/calc/lib/base.py
+++ b/src/viperleed/calc/lib/base.py
@@ -17,9 +17,7 @@ import logging
 import multiprocessing
 import os
 import re
-import shutil
 import subprocess
-import sys
 
 import numpy as np
 import scipy.spatial as sps
@@ -353,43 +351,3 @@ def available_cpu_count():
         pass
 
     return -1
-
-
-def copytree_exists_ok(source, destination):
-    """Copy the whole tree at the `source` directory to `destination`.
-
-    This is a wrapper around the shutil.copytree function that
-    maintains backwards compatibility down to python v3.5.
-
-    Parameters
-    ----------
-    source : Path
-        Base of the directory tree to be copied. Notice that symlinks
-        in `source` will NOT be handled correctly for python < 3.8.
-    destination : Path
-        Path to the directory that will mirror source and its contents.
-        It is created if it does not exist yet.
-
-    Returns
-    -------
-    None.
-    """
-    if sys.version_info >= (3, 8):
-        # dirs_exist_ok was introduced in python 3.8:
-        # https://docs.python.org/3/library/shutil.html#shutil.copytree
-        # pylint: disable-next=unexpected-keyword-arg
-        shutil.copytree(source, destination, dirs_exist_ok=True)
-        return
-    # For earlier python versions, we need to do things manually. We
-    # use a simplified version of the implementation of copytree from
-    # shutil for py3.8. We assume that source and destination are Path
-    # objects, and that we don't have anything special like symlinks.
-    # The next line will not work in py<3.5 because of exist_ok.
-    destination.mkdir(parents=True, exist_ok=True)
-    for srcentry in source.glob('*'):
-        dstentry = destination / srcentry.name
-        if srcentry.is_dir():
-            copytree_exists_ok(srcentry, dstentry)
-        else:  # file
-            shutil.copy2(srcentry, dstentry)
-    shutil.copystat(source, destination)

--- a/src/viperleed/calc/lib/fs_util.py
+++ b/src/viperleed/calc/lib/fs_util.py
@@ -1,0 +1,57 @@
+"""Module fs_util of viperleed.calc.lib.
+
+Defines backward-compatible file-system-related functionality. Mostly
+functions available in the shutil standard-library module.
+"""
+
+__authors__ = (
+    'Michele Riva (@michele-riva)',
+    )
+__copyright__ = 'Copyright (c) 2019-2025 ViPErLEED developers'
+__created__ = '2025-03-11'
+__license__ = 'GPLv3+'
+
+import shutil
+import sys
+
+PY38 = 3, 8
+
+
+def copytree_exists_ok(source, destination):
+    """Copy the whole tree at the `source` directory to `destination`.
+
+    This is a wrapper around the shutil.copytree function that
+    maintains backwards compatibility down to python v3.5.
+
+    Parameters
+    ----------
+    source : Path
+        Base of the directory tree to be copied. Notice that symlinks
+        in `source` will NOT be handled correctly for python < 3.8.
+    destination : Path
+        Path to the directory that will mirror source and its contents.
+        It is created if it does not exist yet.
+
+    Returns
+    -------
+    None.
+    """
+    if sys.version_info >= PY38:
+        # dirs_exist_ok was introduced in python 3.8:
+        # https://docs.python.org/3/library/shutil.html#shutil.copytree
+        # pylint: disable-next=unexpected-keyword-arg
+        shutil.copytree(source, destination, dirs_exist_ok=True)
+        return
+    # For earlier python versions, we need to do things manually. We
+    # use a simplified version of the implementation of copytree from
+    # shutil for py3.8. We assume that source and destination are Path
+    # objects, and that we don't have anything special like symlinks.
+    # The next line will not work in py<3.5 because of exist_ok.
+    destination.mkdir(parents=True, exist_ok=True)
+    for srcentry in source.glob('*'):
+        dstentry = destination / srcentry.name
+        if srcentry.is_dir():
+            copytree_exists_ok(srcentry, dstentry)
+        else:  # file
+            shutil.copy2(srcentry, dstentry)
+    shutil.copystat(source, destination)

--- a/src/viperleed/calc/lib/fs_util.py
+++ b/src/viperleed/calc/lib/fs_util.py
@@ -84,12 +84,14 @@ def move(src, dst, copy_function=shutil.copy2):
     FileExistsError
         If `dst` exists.
     """
-    if Path(dst).exists():
-        raise FileExistsError(f'Cannot move {src} to {dst}. Destination '
-                              'already exists.')
     if sys.version_info < PY39:
         # os.PathLike is supported since python 3.9:
         # https://docs.python.org/3/library/shutil.html#shutil.move
         src = os.fspath(src)
         dst = os.fspath(dst)
-    shutil.move(src, dst, copy_function=copy_function)
+    try:
+        shutil.move(src, dst, copy_function=copy_function)
+    except OSError as exc:
+        if Path(dst).exists():
+            raise FileExistsError(str(exc)) from None
+        raise

--- a/src/viperleed/calc/lib/fs_util.py
+++ b/src/viperleed/calc/lib/fs_util.py
@@ -88,7 +88,8 @@ def move(src, dst, copy_function=shutil.copy2):
         raise FileExistsError(f'Cannot move {src} to {dst}. Destination '
                               'already exists.')
     if sys.version_info < PY39:
-        # os.PathLike is supported since Python 3.9
+        # os.PathLike is supported since python 3.9:
+        # https://docs.python.org/3/library/shutil.html#shutil.move
         src = os.fspath(src)
         dst = os.fspath(dst)
     shutil.move(src, dst, copy_function=copy_function)

--- a/src/viperleed/calc/lib/fs_util.py
+++ b/src/viperleed/calc/lib/fs_util.py
@@ -11,10 +11,13 @@ __copyright__ = 'Copyright (c) 2019-2025 ViPErLEED developers'
 __created__ = '2025-03-11'
 __license__ = 'GPLv3+'
 
+import os
+from pathlib import Path
 import shutil
 import sys
 
 PY38 = 3, 8
+PY39 = 3, 9
 
 
 def copytree_exists_ok(source, destination):
@@ -55,3 +58,37 @@ def copytree_exists_ok(source, destination):
         else:  # file
             shutil.copy2(srcentry, dstentry)
     shutil.copystat(source, destination)
+
+
+def move(src, dst, copy_function=shutil.copy2):
+    """Recursively move a file or directory to another location.
+
+    This function is a wrapper around shutil.move that accepts
+    a generic os.PathLike for its arguments rather than mere
+    strings.
+
+    Parameters
+    ----------
+    src : os.PathLike
+        Path to the original file or directory.
+    dst : os.PathLike
+        If the destination is a directory or a symlink to a directory,
+        the source is moved inside the directory. The destination path
+        must not already exist.
+    copy_function : callable, optional
+        A callable used to copy the source directory, if it cannot be
+        simply renamed. Default is shutil.copy2.
+
+    Raises
+    ------
+    FileExistsError
+        If `dst` exists.
+    """
+    if Path(dst).exists():
+        raise FileExistsError(f'Cannot move {src} to {dst}. Destination '
+                              'already exists.')
+    if sys.version_info < PY39:
+        # os.PathLike is supported since Python 3.9
+        src = os.fspath(src)
+        dst = os.fspath(dst)
+    shutil.move(src, dst, copy_function=copy_function)

--- a/src/viperleed/calc/sections/cleanup.py
+++ b/src/viperleed/calc/sections/cleanup.py
@@ -18,7 +18,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 from viperleed.calc import DEFAULT_WORK_HISTORY
 from viperleed.calc import LOG_PREFIX
 from viperleed.calc import ORIGINAL_INPUTS_DIR_NAME
-from viperleed.calc.lib.fs_util import copytree_exists_ok
+from viperleed.calc.lib import fs_util
 from viperleed.calc.lib.log_utils import close_all_handlers
 from viperleed.calc.lib.time_utils import DateTimeFormat
 
@@ -215,7 +215,7 @@ def _organize_supp_out(path, outfiles):
             if not _dir.is_dir():
                 continue
             try:
-                copytree_exists_ok(_dir, out_path / _dir.name)
+                fs_util.copytree_exists_ok(_dir, out_path / _dir.name)
             except OSError:
                 logger.error(f"Error moving {folder} directory {_dir.name}: ",
                              exc_info=True)
@@ -279,7 +279,7 @@ def _collect_deltas(tensor_index, path):
             errors = []
             for delta_file in deltalist:
                 try:
-                    shutil.move(delta_file, destination / delta_file.name)
+                    fs_util.move(delta_file, destination / delta_file.name)
                 except OSError as err:
                     errors.append(err)
             if errors:
@@ -384,7 +384,7 @@ def move_oldruns(rp, prerun=False):
             if not prerun or f in iofiles:
                 shutil.copy2(f, work_hist_path / f)
             else:
-                shutil.move(f, work_hist_path / f)
+                fs_util.move(f, work_hist_path / f)
         except Exception:
             logger.warning(f"Error copying {f} to {work_hist_path / f}."
                            " File may get overwritten.")
@@ -393,7 +393,7 @@ def move_oldruns(rp, prerun=False):
             if not prerun:
                 shutil.copytree(d, work_hist_path / d)
             else:
-                shutil.move(d, work_hist_path / d)
+                fs_util.move(d, work_hist_path / d)
         except Exception:
             logger.warning(f"Error copying {d} to {work_hist_path / d}."
                            " Files in directory may get overwritten.")

--- a/src/viperleed/calc/sections/cleanup.py
+++ b/src/viperleed/calc/sections/cleanup.py
@@ -18,7 +18,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 from viperleed.calc import DEFAULT_WORK_HISTORY
 from viperleed.calc import LOG_PREFIX
 from viperleed.calc import ORIGINAL_INPUTS_DIR_NAME
-from viperleed.calc.lib.base import copytree_exists_ok
+from viperleed.calc.lib.fs_util import copytree_exists_ok
 from viperleed.calc.lib.log_utils import close_all_handlers
 from viperleed.calc.lib.time_utils import DateTimeFormat
 

--- a/src/viperleed/calc/sections/rfactor.py
+++ b/src/viperleed/calc/sections/rfactor.py
@@ -21,6 +21,7 @@ from viperleed.calc import DEFAULT_WORK
 from viperleed.calc.files import iorfactor
 from viperleed.calc.files import iotensors
 from viperleed.calc.files.iorefcalc import readFdOut
+from viperleed.calc.lib import fs_util
 from viperleed.calc.lib import leedbase
 from viperleed.calc.lib.checksums import validate_multiple_files
 
@@ -489,7 +490,7 @@ def run_legacy_rfactor(sl, rp, for_error, name, theobeams, index, only_vary):
 
     # move log file to supp
     try:
-        shutil.move(compile_log, "compile_logs" / compile_log)
+        fs_util.move(compile_log, "compile_logs" / compile_log)
     except OSError:
         logger.warning(f"Could not move {compile_log} to SUPP")
     # run

--- a/tests/calc/sections/conftest.py
+++ b/tests/calc/sections/conftest.py
@@ -33,7 +33,7 @@ import pytest_cases
 
 from viperleed.calc import DEFAULT_WORK
 from viperleed.calc.files import tenserleed
-from viperleed.calc.lib.base import copytree_exists_ok
+from viperleed.calc.lib.fs_util import copytree_exists_ok
 from viperleed.calc.lib.version import Version
 from viperleed.calc.run import run_calc
 


### PR DESCRIPTION
According to the [python docs](https://docs.python.org/3/library/shutil.html#shutil.move), `shutil.move` supports `Path` objects only since python 3.9. This PR introduces a backward-compatible version that we can safely use, and fixes the occurrences of usage of `shutil.move` with `Path` argument(s).

Tests will be added in #198, as some test functionality added there makes testing easier.