### PR TITLE
Automatically remove work directory upon successful execution

### DIFF
--- a/doc/content/calc/example_systems/Ag(100).rst
+++ b/doc/content/calc/example_systems/Ag(100).rst
@@ -195,8 +195,6 @@ Your root folder should now look like this:
     │   ├── original_inputs/
     │   │   └── ...
     │   └── ...
-    ├── work/
-    │   └── ...
     ├── EXPBEAMS.csv
     ├── history.info
     ├── IVBEAMS
@@ -210,10 +208,7 @@ Your root folder should now look like this:
     └── viperleed-calc-<timestamp>.log
 
 Folders :file:`OUT` and :file:`SUPP` always contain the main
-:ref:`results <files>` of the calculation. Folder :file:`work`
-is where |calc| actually runs. It is kept for debugging purposes,
-and you can safely delete it (use the ``--delete-workdir``
-:ref:`command-line argument <cli_calc>` to do this automatically).
+:ref:`results <files>` of the calculation.
 Files :ref:`ivbeams`, :ref:`phaseshifts`, and :ref:`vibrocc` were
 automatically created by |calc|. :file:`POSCAR_user` is an exact
 copy of the :ref:`poscar` file given as input the first time |calc|

--- a/doc/content/calc/how_to_run.rst
+++ b/doc/content/calc/how_to_run.rst
@@ -109,9 +109,11 @@ A typical call may look like this:
 
             viperleed calc -w %work_path% -t %tensorleed_path%
 
-The directory at ``work_path`` is the one where the calculation will be
+The directory at :file:`work_path` is the one where the calculation will be
 executed and all temporary files will be stored. It is created if it does not
-exist. The ``tensorleed_path`` is the path to the :ref:`install_tensorleed`.
+exist, and automatically deleted upon successful termination (unless the ``-k``
+command-line flag is specified).
+The ``tensorleed_path`` is the path to the :ref:`install_tensorleed`.
 If the ``-t`` option is not given, ViPErLEED looks for the TensErLEED source
 code under the path specified by the :envvar:`VIPERLEED_TENSORLEED`
 :term:`environment variable` (see also :ref:`set_envvar`).
@@ -164,7 +166,9 @@ a :ref:`manifest` file that lists the files and directories to be copied back.
 :numref:`list_organization_output` shows an example of the directory tree
 after a run. The :file:`my_work` directory may be on a different file-system
 path (including a different drive, a network path, or a remote server) or be
-a subfolder of :file:`my_surface`.
+a subfolder of :file:`my_surface`. It is shown mainly for illustration
+purposes, as the work directory is automatically deleted after a successful
+execution (unless the ``-k`` command-line flag is given).
 
 .. _list_organization_output:
 .. code-block:: console
@@ -207,7 +211,7 @@ a subfolder of :file:`my_surface`.
     ├── VIBROCC              <-- output, created or edited by calc
     └── viperleed-calc-<timestamp>.log
 
-    my_work/
+    my_work/                 <-- deleted upon successful termination
     ├── manifest
     └── ...
 

--- a/doc/content/command_line_tools.rst
+++ b/doc/content/command_line_tools.rst
@@ -84,3 +84,5 @@ tool for running |LEED-IV| calculations.
     manually running :ref:`bookkeeper` after |calc|.
     Removed the ``--job-name``, ``--history-name``, and ``--work-history-name``
     arguments.
+    Removed the ``--delete-workdir`` argument, whose default was ``False``.
+    It is replaced by ``--keep-workdir``.

--- a/doc/content/command_line_tools.rst
+++ b/doc/content/command_line_tools.rst
@@ -88,5 +88,7 @@ tool for running |LEED-IV| calculations.
 .. versionremoved:: 0.13.0
     The ``--job-name``, ``--history-name``, and ``--work-history-name``
     arguments.
+
+.. versionchanged:: 0.13.0
     Removed the ``--delete-workdir`` argument, whose default was ``False``.
     It is replaced by ``--keep-workdir``.

--- a/src/viperleed/calc/cli.py
+++ b/src/viperleed/calc/cli.py
@@ -74,7 +74,8 @@ class ViPErLEEDCalcCLI(ViPErLEEDCLI, cli_name='calc'):
         bookkeeper.run(mode=BookkeeperMode.ARCHIVE)
 
         # Finally clean up work if requested
-        if args.delete_workdir:
+        keep_workdir = args.keep_workdir or exit_code
+        if not keep_workdir:
             try:
                 shutil.rmtree(work_path)
             except OSError as exc:
@@ -126,8 +127,10 @@ class ViPErLEEDCalcCLI(ViPErLEEDCLI, cli_name='calc'):
             action='store_true',
             )
         parser.add_argument(
-            '--delete-workdir',
-            help='delete work directory after execution',
+            '--keep-workdir',
+            help=('do not delete the work directory after execution. By '
+                  'default, the work directory is also not deleted in '
+                  'case of errors.'),
             action='store_true',
             )
 

--- a/src/viperleed/calc/cli.py
+++ b/src/viperleed/calc/cli.py
@@ -127,7 +127,7 @@ class ViPErLEEDCalcCLI(ViPErLEEDCLI, cli_name='calc'):
             action='store_true',
             )
         parser.add_argument(
-            '--keep-workdir',
+            '--keep-workdir', '-k',
             help=('do not delete the work directory after execution. By '
                   'default, the work directory is also not deleted in '
                   'case of errors.'),

--- a/tests/calc/bookkeeper/bookkeeper/test_run_with_calc.py
+++ b/tests/calc/bookkeeper/bookkeeper/test_run_with_calc.py
@@ -53,9 +53,8 @@ class TestBookkeeperDuringCalc(_TestBookkeeperRunBase):
         """Check results when calc fails because of missing inputs."""
         cli = ViPErLEEDCalcCLI()
         with execute_in_dir(tmp_path):
-            calc_error = cli(['--delete-workdir'])
+            calc_error = cli([])
             assert calc_error
             bookkeeper = Bookkeeper()
             exit_code = bookkeeper.run('fix')
             assert exit_code is BookkeeperExitCode.NOTHING_TO_DO
-        assert not (tmp_path/'work').exists()

--- a/tests/calc/test_cli.py
+++ b/tests/calc/test_cli.py
@@ -73,7 +73,7 @@ class TestCalcCliCall:
                                   mock_implementation,
                                   capsys,
                                   mocker):
-         """Check complaints are printed when removing work fails."""
+        """Check complaints are printed when removing work fails."""
         cli = ViPErLEEDCalcCLI()
         mocks = mock_implementation(exit_code=0)
         mocks['rmtree'].side_effect = OSError

--- a/tests/calc/test_cli.py
+++ b/tests/calc/test_cli.py
@@ -63,7 +63,7 @@ class TestCalcCliCall:
         cli = ViPErLEEDCalcCLI()
         mocks = mock_implementation(exit_code=0)
         with execute_in_dir(tmp_path):
-            error = cli(['--delete-workdir'])
+            error = cli([])
         assert not error
         mocks['rmtree'].assert_called_once_with(tmp_path/DEFAULT_WORK)
 
@@ -76,7 +76,7 @@ class TestCalcCliCall:
         mocks = mock_implementation(exit_code=0)
         mocks['rmtree'].side_effect = OSError
         with execute_in_dir(tmp_path):
-            error = cli(['--delete-workdir'])
+            error = cli([])
         assert not error
         captured = capsys.readouterr().out
         # pylint: disable-next=magic-value-comparison
@@ -92,6 +92,15 @@ class TestCalcCliCall:
         assert result is exit_code
         assert bool(result)    # Should fake an error condition
         mocks['rmtree'].assert_not_called()  # work should stay
+
+    def test_keep_workdir(self, tmp_path, mock_implementation):
+        """Check that work is not deleted if requested."""
+        cli = ViPErLEEDCalcCLI()
+        mocks = mock_implementation(exit_code=0)
+        with execute_in_dir(tmp_path):
+            error = cli(['--keep-workdir'])
+        assert not error
+        mocks['rmtree'].assert_not_called()
 
     def test_success(self, tmp_path, mock_implementation, mocker):
         """Check the successful call to ViPErLEEDCalcCLI."""
@@ -116,6 +125,7 @@ class TestCalcCliCall:
             'log_level': None,
             'manifest': mocker.call(tmp_path),
             'multiprocess': mocker.call(),
+            'rmtree': mocker.call(tmp_path/DEFAULT_WORK),
             'run': None,
             'tensors_deltas': None,
             }
@@ -125,7 +135,6 @@ class TestCalcCliCall:
                 mock.assert_called_once()
             else:
                 assert mock.mock_calls == [call]
-        mocks['rmtree'].assert_not_called()
 
 
 class TestCalcParser:

--- a/tests/calc/test_cli.py
+++ b/tests/calc/test_cli.py
@@ -7,7 +7,6 @@ __copyright__ = 'Copyright (c) 2019-2025 ViPErLEED developers'
 __created__ = '2023-08-02'
 __license__ = 'GPLv3+'
 
-from argparse import Namespace
 import os
 
 import pytest
@@ -37,7 +36,7 @@ class TestCalcCliCall:
     """Tests for the __call__ method of ViPErLEEDCalcCLI."""
 
     @fixture(name='mock_implementation')
-    def fixture_mock_implementation(self, tmp_path, mocker):
+    def fixture_mock_implementation(self, mocker):
         """Replace implementation details with mocks."""
         def _mock(exit_code):
             return {
@@ -59,7 +58,7 @@ class TestCalcCliCall:
                 }
         return _mock
 
-    def test_delete_workdir(self, tmp_path, mock_implementation, mocker):
+    def test_delete_workdir(self, tmp_path, mock_implementation):
         """Check the successful removal of the work directory."""
         cli = ViPErLEEDCalcCLI()
         mocks = mock_implementation(exit_code=0)
@@ -71,8 +70,7 @@ class TestCalcCliCall:
     def test_delete_workdir_fails(self,
                                   tmp_path,
                                   mock_implementation,
-                                  capsys,
-                                  mocker):
+                                  capsys):
         """Check complaints are printed when removing work fails."""
         cli = ViPErLEEDCalcCLI()
         mocks = mock_implementation(exit_code=0)
@@ -81,6 +79,7 @@ class TestCalcCliCall:
             error = cli(['--delete-workdir'])
         assert not error
         captured = capsys.readouterr().out
+        # pylint: disable-next=magic-value-comparison
         assert 'Error deleting' in captured
 
     def test_exit_code(self, tmp_path, mock_implementation, mocker):
@@ -251,7 +250,8 @@ class TestCopyTensorsDeltas:
         """Check correct copying of all Tensors/Deltas."""
         copy = mocker.patch(f'{_MODULE}.copytree_exists_ok')
         _copy_tensors_and_deltas_to_work(mocker.MagicMock(), all_tensors=True)
-        assert copy.call_count == 2  # Tensors and Deltas folders
+        n_folders = 2  # Tensors and Deltas folders
+        assert copy.call_count == n_folders
 
     def test_copy_all_not_found(self, mocker, caplog):
         """Check correct copying of all Tensors/Deltas."""
@@ -259,7 +259,8 @@ class TestCopyTensorsDeltas:
         copy = mocker.patch(f'{_MODULE}.copytree_exists_ok',
                             side_effect=FileNotFoundError)
         _copy_tensors_and_deltas_to_work(mocker.MagicMock(), all_tensors=True)
-        assert copy.call_count == 2  # Tried Tensors and Deltas folders
+        n_folders_tried = 2  # Tried Tensors and Deltas folders
+        assert copy.call_count == n_folders_tried
         assert not caplog.text
 
     def test_copy_most_recent(self, mocker):
@@ -268,17 +269,20 @@ class TestCopyTensorsDeltas:
         mocker.patch('pathlib.Path.is_file', return_value=True)
         copy = mocker.patch('shutil.copy2')
         _copy_tensors_and_deltas_to_work(mocker.MagicMock(), all_tensors=False)
-        assert copy.call_count == 2   # Tensors.zip and Deltas.zip
+        n_files = 2  # Tensors.zip and Deltas.zip
+        assert copy.call_count == n_files
 
     def test_copy_most_recent_missing(self, mocker):
         """Check no complaints when no Tensors exist."""
         def _is_file(path):
+            # pylint: disable-next=magic-value-comparison
             return 'Tensors' in path.name
         mocker.patch(f'{_MODULE}.getMaxTensorIndex', return_value=123)
         mocker.patch('pathlib.Path.is_file', _is_file)
         copy = mocker.patch('shutil.copy2')
         _copy_tensors_and_deltas_to_work(mocker.MagicMock(), all_tensors=False)
-        assert copy.call_count == 1   # Only Tensors.zip, no Deltas.zip
+        n_files = 1  # Only Tensors.zip, no Deltas.zip
+        assert copy.call_count == n_files
 
     def test_copy_most_recent_none(self, mocker, caplog):
         """Check no complaints when no Tensors exist."""


### PR DESCRIPTION
Fixes #316.

The implementation is slightly different than I originally suggested in https://github.com/viperleed/viperleed/issues/316#issuecomment-2772040216:
- if the `--keep-workdir` flag is not given, the work directory is deleted unless `run_calc` exited with any error condition.
- if the `--keep-workdir` flag is given, never delete the work directory, irrespective of the exit code.

The reason not to implement it as I originally suggested is that we would then need to make the `--keep-workdir` an argument rather than a flag, so people would need to call with one of the following:

```
viperleed calc                       # work deleted if no errors
viperleed calc --keep-workdir True   # always keep work
viperleed calc --keep-workdir False  # always delete work
```

Concerning the "error condition": the current implementation will consider a `KeyboardInterrupt` during `section_loop` as an error condition, so the work directory will stay. I'd like your thoughts about this.
