### PR TITLE
Do not use heuristic to find potential domain subfolders

### DIFF
--- a/src/viperleed/calc/bookkeeper/bookkeeper.py
+++ b/src/viperleed/calc/bookkeeper/bookkeeper.py
@@ -731,6 +731,14 @@ class Bookkeeper:
         # as clear_for_next_calc_run does internally re-collect info.
         main_root = RootExplorer(self.cwd, self)
         main_root.collect_info(silent=True)
+
+        # Store information in the root explorers about the presence
+        # of domains. This has impact on which input files we may store
+        # in history as well as which ones will be kept as non-suffixed
+        # in the root directory. We should not rely on DomainFinder,
+        # whose find_potential_domains is bugged. See also #344.
+        self._root.has_domains = True
+        main_root.has_domains = True
         main_exit_code, main_folder = self._run_one_domain(mode, **kwargs)
         exit_codes = [
             main_exit_code,

--- a/src/viperleed/calc/bookkeeper/domain_finder.py
+++ b/src/viperleed/calc/bookkeeper/domain_finder.py
@@ -121,6 +121,16 @@ class DomainFinder:
 
     def find_potential_domains(self):
         """Return paths to subfolders of self.path that may be domains."""
+        raise NotImplementedError(
+            'The current implementation of find_potential_domains is faulty '
+            'as it will not treat correctly the work directory nor any other '
+            'subfolder in which temporary calculations may have been run. '
+            'See also https://github.com/viperleed/viperleed/issues/344.'
+            )
+        return self._find_potential_domains_buggy()
+
+    def _find_potential_domains_buggy(self):
+        """Return paths to subfolders of self.path that may be domains."""
         subfolders = (d for d in self.path.iterdir()
                       if d.is_dir()
                       and d.name not in _NOT_A_DOMAIN_SUBFOLDER)

--- a/src/viperleed/calc/bookkeeper/root_explorer.py
+++ b/src/viperleed/calc/bookkeeper/root_explorer.py
@@ -56,7 +56,7 @@ class RootExplorer:
     def __init__(self, path, bookkeeper):
         """Initialize this explorer at `path` for a `bookkeeper`."""
         self._path = Path(path).resolve()
-        self._has_domains = False      # Is this the root of a DOMAINS?
+        self.has_domains = False       # Is this the root of a DOMAINS?
         self._logs = None              # LogFiles, set in collect_info
         self._files_to_archive = None  # See _collect_files_to_archive
         self.tensors = TensorAndDeltaInfo(self.path)
@@ -110,7 +110,12 @@ class RootExplorer:
             self.tensors.collect()
             self._collect_files_to_archive()
             self.history.collect_subfolders()
-            self._find_potential_domain_subfolders()
+            # TODO: consider whether we can partly undo the changes
+            # that fixed #344 when we fix #215. Then we would likely
+            # be reading the PARAMETERS file and know whether we're
+            # running in a DOMAINS tree without the need of having
+            # Bookkeeper let us know by setting .has_domains.
+            # self._find_potential_domain_subfolders()
 
     def complain_about_edited_files(self):
         """Log warnings if any _edited file is found in root."""
@@ -331,7 +336,7 @@ class RootExplorer:
         name_fmts = name_fmts or ('{}',)
         if only_files is None:
             only_files = STATE_FILES
-        dont_complain = set(SKIP_IN_DOMAIN_MAIN if self._has_domains else ())
+        dont_complain = set(SKIP_IN_DOMAIN_MAIN if self.has_domains else ())
         for file in only_files:
             cwd_file = self.path / file
             patterns = [fmt.format(file) for fmt in name_fmts]
@@ -391,7 +396,7 @@ class RootExplorer:
     def _find_potential_domain_subfolders(self):
         """Find all subfolders of self.path that look like subdomains."""
         finder = DomainFinder(self.workhistory.bookkeeper)
-        self._has_domains = any(finder.find_potential_domains())
+        self.has_domains = any(finder.find_potential_domains())
 
     def _log_failures_when_copying_input_files(self, failed):
         """Emit logging errors about failures to pull input files.

--- a/tests/calc/bookkeeper/bookkeeper/test_archive.py
+++ b/tests/calc/bookkeeper/bookkeeper/test_archive.py
@@ -11,10 +11,18 @@ __copyright__ = 'Copyright (c) 2019-2025 ViPErLEED developers'
 __created__ = '2023-08-02'
 __license__ = 'GPLv3+'
 
+from pytest_cases import parametrize
+
 from viperleed.calc.bookkeeper.history.meta import _METADATA_NAME
 from viperleed.calc.bookkeeper.mode import BookkeeperMode
 from viperleed.calc.constants import DEFAULT_HISTORY
+from viperleed.calc.constants import DEFAULT_OUT
+from viperleed.calc.constants import DEFAULT_SUPP
+from viperleed.calc.constants import DEFAULT_WORK
+from viperleed.calc.constants import LOG_PREFIX
 
+from ....helpers import filesystem_from_dict
+from ..conftest import MOCK_ORIG_CONTENT
 from .run_bookkeeper_base import _TestBookkeeperRunBase
 
 
@@ -23,9 +31,14 @@ class TestBookkeeperArchive(_TestBookkeeperRunBase):
 
     mode = BookkeeperMode.ARCHIVE
 
-    def test_archive_after_calc_exec(self, after_calc_execution, caplog):
+    def test_archive_after_calc_exec(self,
+                                     after_calc_execution,
+                                     caplog,
+                                     **kwargs):
         """Check correct storage of history files in ARCHIVE mode."""
-        self.run_archive_after_calc_and_check(after_calc_execution, caplog)
+        self.run_archive_after_calc_and_check(after_calc_execution,
+                                              caplog,
+                                              **kwargs)
 
     def test_archive_domains(self,
                              domains_after_calc_execution,
@@ -93,3 +106,31 @@ class TestBookkeeperArchive(_TestBookkeeperRunBase):
         """Check no archiving happens before calc runs."""
         self.run_before_calc_exec_and_check(before_calc_execution, caplog)
         self.check_no_warnings(caplog, exclude_msgs=('metadata',))
+
+    @parametrize(workname=(DEFAULT_WORK, 'some_other_folder'))
+    def test_issue_344(self, workname, after_calc_execution, caplog):
+        """Ensure Issue #344 does not present itself anymore."""
+        bookkeeper, *_ = after_calc_execution
+        cwd = bookkeeper.cwd
+
+        # The issue came up if (i) a STATE_FILE was missing from OUT
+        vibrocc_out = 'VIBROCC'
+        try:
+            (cwd/DEFAULT_OUT/vibrocc_out).unlink()
+        except FileNotFoundError:  # Probably old-style with _OUT
+            vibrocc_out_p = next((cwd/DEFAULT_OUT).glob('VIBROCC_OUT*'))
+            vibrocc_out_p.unlink()
+            vibrocc_out = vibrocc_out_p.name
+        # (ii) there was a work directory
+        work_tree = {
+            f'{LOG_PREFIX}_timestamp.log': '',
+            DEFAULT_OUT: {},
+            DEFAULT_SUPP: {},
+            }
+        work_dir = cwd/workname
+        work_dir.mkdir()
+        filesystem_from_dict(work_tree, work_dir)
+        self.test_archive_after_calc_exec(after_calc_execution,
+                                          caplog,
+                                          missing_out_files={'VIBROCC'})
+        self._check_file_contents(cwd/'VIBROCC', MOCK_ORIG_CONTENT)

--- a/tests/calc/bookkeeper/test_domain_finder.py
+++ b/tests/calc/bookkeeper/test_domain_finder.py
@@ -120,6 +120,7 @@ class TestDomainFinder:
         assert result is mock_from_main.return_value
         mock_from_main.assert_called_once()
 
+    @pytest.mark.xfail(reason='Buggy. See #344')
     def test_find_potential_domains(self, make_finder, tmp_path, caplog):
         """Test the find_potential_domains method."""
         caplog.set_level(0)  # All messages

--- a/tests/calc/bookkeeper/test_root_explorer.py
+++ b/tests/calc/bookkeeper/test_root_explorer.py
@@ -216,8 +216,7 @@ class TestRootExplorer:
         # pylint: disable-next=protected-access           # OK in tests
         explorer._find_potential_domain_subfolders()
         mock_finder.find_potential_domains.assert_called_once()
-        # pylint: disable-next=protected-access           # OK in tests
-        assert explorer._has_domains == has_domains
+        assert explorer.has_domains == has_domains
 
     _remove_files = {
         '_remove_ori_files': [f'{file}{ORI_SUFFIX}' for file in STATE_FILES],
@@ -402,8 +401,7 @@ class TestRootExplorerCopyStateFilesFrom:
                                            info,
                                            call_copy):
         """Test the _copy_state_files_from method for the main domain root."""
-        # pylint: disable-next=protected-access           # OK in tests
-        explorer._has_domains = True
+        explorer.has_domains = True
         failures, exc_info = call_copy(info.missing, info.fail, None)
         for file in info.no_complain:
             try:


### PR DESCRIPTION
Fixes #344.

See https://github.com/viperleed/viperleed/issues/344#issuecomment-2878665763 for details.

Adds also regression test in `tests/calc/bookkeeper/bookkeeper/test_archive.py`