### PR TITLE
Fix links to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For installation instructions see
 For a documentation of the `viperleed` Python API see
 <https://viperleed.org/content/api.html>
 
-[![Documentation Status](https://readthedocs.org/projects/viperleed/badge/?version=latest)](https://viperleed.readthedocs.io/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/viperleed/badge/?version=stable)](https://viperleed.readthedocs.io/stable/?badge=stable)
 
 
 #### Reporting bugs

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ processing, and analysis of LEED-*I*(*V*) results, calculation of theoretical
 *I*(*V*) curves based on a structural model of a surface, and optimization of
 such a model to best fit the experimental results.
 
-You can find the full documentation under <https://viperleed.org>.
+You can find the full documentation under <https://www.viperleed.org>.
 
 This repository contains the `viperleed.calc` package, the graphical user
 interface (GUI) and the software related to the ViPErLEED electronics.
@@ -19,10 +19,10 @@ The TensErLEED back-end code used by `viperleed.calc` is available under
 <https://github.com/viperleed/viperleed-tensorleed>
 
 For installation instructions see
-<https://viperleed.org/content/installation.html>
+<https://www.viperleed.org/stable/content/installation.html>
 
 For a documentation of the `viperleed` Python API see
-<https://viperleed.org/content/api.html>
+<https://www.viperleed.org/stable/content/api.html>
 
 [![Documentation Status](https://readthedocs.org/projects/viperleed/badge/?version=stable)](https://viperleed.readthedocs.io/stable/?badge=stable)
 


### PR DESCRIPTION
Fixes some issues with links to the documentation in the README.md file.

@amimre: I somehow can't find any longer the "latest" build on readthedocs, and the current default changed to "stable". I tried to pull it back or renaming "stable", but did not manage. Perhaps we should sit together for a quick look?