### PR TITLE
Fix encoding in log files

### DIFF
--- a/src/viperleed/calc/bookkeeper/log.py
+++ b/src/viperleed/calc/bookkeeper/log.py
@@ -50,7 +50,10 @@ def add_bookkeeper_logfile(at_path):
                            logging.FileHandler,
                            baseFilename=str(bookkeeper_log))
     if not any(has_log):
-        LOGGER.addHandler(logging.FileHandler(bookkeeper_log, mode='a'))
+        log_handler = logging.FileHandler(bookkeeper_log,
+                                          mode='a',
+                                          encoding='utf-8')
+        LOGGER.addHandler(log_handler)
 
 
 def ensure_has_stream_handler():

--- a/src/viperleed/calc/bookkeeper/log.py
+++ b/src/viperleed/calc/bookkeeper/log.py
@@ -179,8 +179,12 @@ class LogFiles:
 
         timestamp = most_recent_log.name[-17:-4]
         last_log_lines = ()
+        open_kwargs = {
+            'encoding': 'utf-8',
+            'errors': 'replace',
+            }
         try:  # pylint: disable=too-many-try-statements
-            with most_recent_log.open('r', encoding='utf-8') as log_file:
+            with most_recent_log.open('r', **open_kwargs) as log_file:
                 last_log_lines = tuple(log_file.readlines())
         except OSError:
             pass

--- a/src/viperleed/calc/lib/log_utils.py
+++ b/src/viperleed/calc/lib/log_utils.py
@@ -132,7 +132,7 @@ def prepare_calc_logger(logger, file_name, with_console):
     """Prepare logger to be used with calc.run."""
     logger.setLevel(logging.INFO)
     formatter = CalcLogFormatter()
-    file_handler = logging.FileHandler(file_name, mode='w')
+    file_handler = logging.FileHandler(file_name, mode='w', encoding='utf-8')
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
     if not with_console:

--- a/tests/_test_data/bookkeeper/utf8_encode_error.log
+++ b/tests/_test_data/bookkeeper/utf8_encode_error.log
@@ -1,0 +1,34 @@
+Starting new log: viperleed-calc-250515-080457.log
+Time of execution: 2025-05-15 08:04:57
+This is ViPErLEED version 0.13.1
+
+Reading structure from file POSCAR
+The POSCAR file will be processed and overwritten. Copying the original POSCAR to POSCAR_user...
+No system name specified. Using name of the parent directory: utf8.
+ViPErLEED is using TensErLEED version 2.0.0.
+# WARNING: Could not find file DISPLACEMENTS. It will not be stored in original_inputs.
+
+STARTING SECTION: INITIALIZATION
+# WARNING: Parameter T_EXPERIMENT is defined but unused.
+# WARNING: Parameter T_DEBYE is defined but unused.
+# WARNING: It looks like the first line in the IVBEAMS file may contain data. Note that the first line should be a header line, so the data will not be read.
+Found unit cell type: hexagonal
+Starting symmetry search...
+Found plane group: p3
+Detected bulk repeat vector: [0.00000 -2.74755 4.33033]
+Checking bulk unit cell...
+Found SUPERLATTICE = (1x1)
+Starting bulk symmetry search...
+Found bulk plane group: p3
+# WARNING: Layer cuts are very close together. The minimum spacing between layers is 0.84 Å. This may lead to convergence issues in the reference calculation. Check the LAYERS_CUTS parameter in the PARAMETERS file.
+Generating BEAMLIST...
+Finishing section at 08:04:58. Section took 1.12 seconds.
+
+Starting cleanup...
+Wrote manifest file successfully.
+
+Finishing execution at 2025-05-15 08:04:58
+Total elapsed time: 1.28 seconds
+
+Executed segments: 0
+

--- a/tests/calc/bookkeeper/test_log.py
+++ b/tests/calc/bookkeeper/test_log.py
@@ -12,6 +12,7 @@ from itertools import permutations
 import logging
 from operator import attrgetter
 from pathlib import Path
+import shutil
 
 import pytest
 from pytest_cases import fixture
@@ -321,6 +322,16 @@ class TestLogFiles:
                 # pylint: disable-next=protected-access   # OK in tests
                 logs._read_most_recent()
             assert logs.most_recent == (expect_time, ())
+
+    def test_most_recent_no_decode_errors(self, logs, data_path, tmp_path):
+        """Ensure Unicode decoding errors are gracefully handled."""
+        utf8_error = tmp_path/'viperleed-calc_123456-123456.log'
+        shutil.copy2(data_path/'bookkeeper'/'utf8_encode_error.log',
+                     utf8_error)
+        # pylint: disable=protected-access                # OK in tests
+        logs._calc = (utf8_error,)
+        logs._read_most_recent()
+        assert logs.most_recent
 
     _attr_needs_update = (
         'files',

--- a/tests/calc/lib/test_log_utils.py
+++ b/tests/calc/lib/test_log_utils.py
@@ -18,6 +18,7 @@ from pytest_cases import fixture
 from pytest_cases import fixture_ref
 from pytest_cases import parametrize
 
+from viperleed.calc.lib.context import execute_in_dir
 from viperleed.calc.lib.log_utils import at_level
 from viperleed.calc.lib.log_utils import close_all_handlers
 from viperleed.calc.lib.log_utils import debug_or_lower
@@ -399,3 +400,15 @@ def test_prepare_calc_logger(console, handler_names, make_logger, monkeypatch):
         assert len(logger.handlers) == len(handler_names)
         assert all(isinstance(h, MockHandler) for h in logger.handlers)
         assert logger.level == logging.INFO
+
+
+def test_calc_log_file_is_utf8(tmp_path):
+    """Ensure that the calc log file is UTF-8 encoded."""
+    logger = logging.getLogger('module')
+    log_name = 'log'
+    with execute_in_dir(tmp_path):
+        prepare_calc_logger(logger, log_name, with_console=False)
+        logger.info('A character that may be not encoded in utf-8: Å')
+        with not_raises(UnicodeDecodeError):
+            with open(log_name, 'r', encoding='utf-8') as log_file:
+                assert log_file.readlines()


### PR DESCRIPTION
I just ran into a problem on Windows where the Angstrom character was encoded in a non-UTF-8 manner. `Bookkeeper` would then fail with a `UnicodeDecodeError`.

This PR ensures that
1. log files are utf-8 encoded
2. bookkeeper gracefully handles decoding problems, for backward compatibility