### PR TITLE
Minor change to disable a nagging info log message

### DIFF
--- a/src/viperleed/calc/files/searchpdf.py
+++ b/src/viperleed/calc/files/searchpdf.py
@@ -603,7 +603,6 @@ def writeSearchReportPdf(rp, outname="Search-report.pdf",
             pass
     close_figures(plt, fig)
 
-
     # Output for Search-report.csv
     if csv_name is None:
         # No CSV output requested
@@ -618,4 +617,3 @@ def writeSearchReportPdf(rp, outname="Search-report.pdf",
         delimiter=',',
         header=headers,
         )
-    logger.info(f'Written to {csv_name}.')


### PR DESCRIPTION
I've noticed that we constantly report that Search-progress.csv has been written while the search is running. This is inconsistent with all other file creations, which are debug-messages at most, and not even that for the minor files that get written continuously during the search.