### PR TITLE
Update license information in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ name = 'viperleed'
 description = 'Tools for quantitative low-energy electron diffraction'
 requires-python = '>=3.7'
 dynamic = ['version']
-license = {file = 'LICENSE.md'}
+license = 'GPL-3.0-or-later'
+license-files = ['LICENSE.md']
 readme = 'README.md'
 dependencies = [
     'fortranformat',
@@ -48,7 +49,6 @@ maintainers = [
     ]
 classifiers = [
     'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
     'Natural Language :: English',
     'Operating System :: MacOS',
     'Operating System :: Microsoft :: Windows',


### PR DESCRIPTION
Adapt license information to the most recent standard (PEP 639, see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license). Fixes `DeprecationWarnings` in `setuptools`.