### PR TITLE
Do not spam empty folder with empty calc/bookkeeper results

### DIFF
--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -198,7 +198,7 @@ class Rparams:
         self.halt = 0
         self.systemName = ''
         self.timestamp = ''
-        self.manifest = ManifestFile(DEFAULT_SUPP, DEFAULT_OUT)
+        self.manifest = ManifestFile()
         self.files_to_out = set()  # Edited or generated, for OUT
         self.fileLoaded = {
             'PARAMETERS': True, 'POSCAR': False,

--- a/src/viperleed/calc/run.py
+++ b/src/viperleed/calc/run.py
@@ -115,7 +115,7 @@ def run_calc(
                 + DateTimeFormat.LOG_CONTENTS.now())
     LOGGER.info(f'This is ViPErLEED version {__version__}\n')
 
-    manifest = ManifestFile(DEFAULT_SUPP, DEFAULT_OUT, log_name)
+    manifest = ManifestFile(log_name)
     try:
         # Read input files and load user arguments
         rpars, slab = _make_rpars_and_slab(manifest, preset_params, slab, home)

--- a/tests/calc/sections/cleanup/test_get_rpars_from_manifest.py
+++ b/tests/calc/sections/cleanup/test_get_rpars_from_manifest.py
@@ -17,6 +17,7 @@ def test_manifest(manifest):
     """Check the return value when a ManifestFile object is given."""
     rpars = get(manifest)
     assert rpars.manifest is manifest
+    assert rpars.TENSOR_INDEX is not None
     # pylint: disable-next=protected-access               # OK in tests
     assert rpars.timer._stopped
 

--- a/tests/calc/sections/cleanup/test_organize_workdir.py
+++ b/tests/calc/sections/cleanup/test_organize_workdir.py
@@ -169,6 +169,20 @@ class TestCollectSuppOut:
         assert organized == expect
         assert not caplog.text
 
+    _folder_to_collector = {
+        DEFAULT_SUPP: _collect_supp_contents,
+        DEFAULT_OUT: _collect_out_contents,
+        }
+
+    @parametrize('folder,which', _folder_to_collector.items())
+    def test_empty(self, folder, which, rpars, tmp_path):
+        """Check that folder is not added to manifest if it is empty."""
+        (tmp_path/'original_inputs').mkdir()
+        (tmp_path/'compile_logs').mkdir()
+        with execute_in_dir(tmp_path):
+            which(rpars)
+        assert folder not in rpars.manifest
+
 
 class TestCopyFilesAndDirectories:
     """Tests for the _copy_files_and_directories helper."""
@@ -185,8 +199,8 @@ class TestCopyFilesAndDirectories:
             if make_tree:
                 filesystem_from_dict(self.tree, workdir)
             with execute_in_dir(workdir):
-                _copy_files_and_directories(*args)
-            return filesystem_to_dict(workdir)
+                result = _copy_files_and_directories(*args)
+            return filesystem_to_dict(workdir), result
         return _run
 
     def test_copy_directories(self, run, workdir):
@@ -194,10 +208,12 @@ class TestCopyFilesAndDirectories:
         target = workdir / 'test_target'
         target.mkdir()
         dirs = [workdir/d for d, c in self.tree.items() if isinstance(c, dict)]
-        copied = run([], dirs, target)
+        copied, (copied_files, copied_dirs) = run([], dirs, target)
         expect = self.tree.copy()
         expect[target.name] = {d.name: self.tree[d.name] for d in dirs}
         assert copied == expect
+        assert not copied_files
+        assert copied_dirs == set(dirs)
 
     def test_copy_fails(self, run, workdir, caplog, mocker):
         """Check logging messages when copying fails."""
@@ -209,7 +225,7 @@ class TestCopyFilesAndDirectories:
         expect[target.name] = {}
         files = [workdir/f for f, c in self.tree.items() if isinstance(c, str)]
         dirs = [workdir/d for d, c in self.tree.items() if isinstance(c, dict)]
-        copied = run(files, dirs, target)
+        copied, result = run(files, dirs, target)
         assert copied == expect
         assert copy_file.call_count == len(files)
         assert copy_dir.call_count == len(dirs)
@@ -218,15 +234,18 @@ class TestCopyFilesAndDirectories:
         log = caplog.text
         assert all(log_msg_file.format(f.name) in log for f in files)
         assert all(log_msg_dir.format(d.name) in log for d in dirs)
+        assert not any(result)
 
     def test_copy_files(self, run, workdir):
         """Check a successful copy of files."""
         target = workdir / 'test_target'
         files = [workdir/f for f, c in self.tree.items() if isinstance(c, str)]
-        copied = run(files, [], target)
+        copied, (copied_files, copied_dirs) = run(files, [], target)
         expect = self.tree.copy()
         expect[target.name] = {f.name: self.tree[f.name] for f in files}
         assert copied == expect
+        assert not copied_dirs
+        assert copied_files == set(files)
 
     def test_copy_non_existing(self, run, workdir):
         """Check no complaints when copying non-existing files/folders."""
@@ -234,8 +253,9 @@ class TestCopyFilesAndDirectories:
         expect = {target.name: {}}
         files = (workdir/'non_existing_file.txt',)
         dirs = (workdir/'non_existing_dir',)
-        copied = run(files, dirs, target, make_tree=False)
+        copied, result = run(files, dirs, target, make_tree=False)
         assert copied == expect
+        assert not any(result)
 
     def test_mkdir_fails(self, run, workdir, caplog, mocker):
         """Check warnings when making the target fails."""
@@ -244,9 +264,10 @@ class TestCopyFilesAndDirectories:
         filesystem_from_dict(self.tree, workdir)  # BEFORE patching
         mocker.patch('pathlib.Path.mkdir', side_effect=OSError)
         expect_log = 'Error creating test_target folder'
-        unchanged = run(files, (), target, make_tree=False)
+        unchanged, result = run(files, (), target, make_tree=False)
         assert unchanged == self.tree
         assert expect_log in caplog.text
+        assert not any(result)
 
 
 class TestOrganizeWorkdir:

--- a/tests/calc/test_run.py
+++ b/tests/calc/test_run.py
@@ -103,7 +103,7 @@ class TestRunCalc:
                 file_name=log_name,
                 with_console=kwargs.get('console_output', True),
                 ),
-            'manifest': mocker.call('SUPP', 'OUT', log_name),
+            'manifest': mocker.call(log_name),
             'make_rp_sl': mocker.call(
                 mocks['manifest'].return_value,
                 kwargs.get('preset_params'),
@@ -153,7 +153,7 @@ class TestRunCalc:
             'prepare_log': mocker.call(mocks['logger'],
                                        file_name=log_name,
                                        with_console=True),
-            'manifest': mocker.call('SUPP', 'OUT', log_name),
+            'manifest': mocker.call(log_name),
             'make_rp_sl': mocker.call(mocks['manifest'].return_value,
                                       None,   # preset_params
                                       None,   # slab
@@ -190,7 +190,7 @@ class TestRunCalc:
             'prepare_log': mocker.call(mocks['logger'],
                                        file_name=log_name,
                                        with_console=True),
-            'manifest': mocker.call('SUPP', 'OUT', log_name),
+            'manifest': mocker.call(log_name),
             'make_rp_sl': mocker.call(mocks['manifest'].return_value,
                                       None,   # preset_params
                                       None,   # slab


### PR DESCRIPTION
Fixes #408.

Here the necessary steps:
- [x] Do not copy back from work empty `SUPP` or `OUT`
- [ ] Do not execute the second bookkeeper call if no inputs were available
- [ ] Remove `history` and `history.info` if no inputs were available
- [ ] Remove `work` if no inputs were available