### PR TITLE
Prevent DeprecationWarnings in Python 3.12 and later

### DIFF
--- a/src/viperleed/gui/mathparse.py
+++ b/src/viperleed/gui/mathparse.py
@@ -34,6 +34,13 @@ BINARY_OPERATIONS = {
     ast.Pow: operator.pow,
     }
 
+CONST_CLS_TO_ATTR = {
+    # Node instance: node attribute for evaluation
+    ast.Constant: 'value',  # Available since 3.6
+    ast.Str: 's',           # Deprecated since 3.8
+    ast.Num: 'n',           # Deprecated since 3.8
+    }
+
 UNARY_OPERATIONS = {
     ast.USub: operator.neg,
     ast.UAdd: operator.pos,
@@ -293,15 +300,12 @@ class MathParser:
 
     def _eval_constant(self, node):
         """Evaluate a node containing a constant value."""
-        if isinstance(node, ast.Constant):    # Available since 3.6
-            ret = node.value
-        elif isinstance(node, ast.Str):       # Deprecated since 3.8
-            ret = node.s
-        elif isinstance(node, ast.Num):       # Deprecated since 3.8
-            ret = node.n
-        else:
+        try:
+            attr = next(v for c, v in CONST_CLS_TO_ATTR.items()
+                        if isinstance(node, c))
+        except StopIteration:
             raise UnsupportedMathError(node)
-        return ret
+        return getattr(node, attr)
 
     @limit_recursion
     def _eval_math_function(self, node, depth):

--- a/src/viperleed/gui/mathparse.py
+++ b/src/viperleed/gui/mathparse.py
@@ -24,6 +24,10 @@ from functools import wraps
 import math
 import operator
 import re
+import sys
+
+PY_3_8 = (3, 8)
+
 
 BINARY_OPERATIONS = {
     ast.Add: operator.add,
@@ -37,9 +41,15 @@ BINARY_OPERATIONS = {
 CONST_CLS_TO_ATTR = {
     # Node instance: node attribute for evaluation
     ast.Constant: 'value',  # Available since 3.6
-    ast.Str: 's',           # Deprecated since 3.8
-    ast.Num: 'n',           # Deprecated since 3.8
     }
+if sys.version_info < PY_3_8:
+    # Add deprecated ast classes for early python versions.
+    # Back in Py37 they were not yet aliases for Constant.
+    # They have been subclasses of Constant since Py3.8.
+    CONST_CLS_TO_ATTR.update({
+        ast.Str: 's',
+        ast.Num: 'n',
+        })
 
 UNARY_OPERATIONS = {
     ast.USub: operator.neg,

--- a/src/viperleed/gui/mathparse.py
+++ b/src/viperleed/gui/mathparse.py
@@ -281,18 +281,24 @@ class MathParser:
         """Recursively evaluate a node."""
         if isinstance(node, ast.Expression):
             ret = self._eval(node.body, depth+1)
-        elif isinstance(node, ast.Constant):  # Available since 3.6
-            ret = node.value
-        elif isinstance(node, ast.Str):       # Deprecated since 3.8
-            ret = node.s
-        elif isinstance(node, ast.Num):       # Deprecated since 3.8
-            ret = node.n
         elif isinstance(node, ast.BinOp):
             ret = self._eval_binary_operation(node, depth+1)
         elif isinstance(node, ast.UnaryOp):
             ret = self._eval_unary_operation(node, depth+1)
         elif isinstance(node, ast.Call):
             ret = self._eval_math_function(node, depth+1)
+        else:
+            ret = self._eval_constant(node)
+        return ret
+
+    def _eval_constant(self, node):
+        """Evaluate a node containing a constant value."""
+        if isinstance(node, ast.Constant):    # Available since 3.6
+            ret = node.value
+        elif isinstance(node, ast.Str):       # Deprecated since 3.8
+            ret = node.s
+        elif isinstance(node, ast.Num):       # Deprecated since 3.8
+            ret = node.n
         else:
             raise UnsupportedMathError(node)
         return ret


### PR DESCRIPTION
The `DeprecationWarning`s came from `ast`, used in `gui.mathparse`. They were not really a problem (will be a problem in 3.14, though), but were very annoying to see in the terminal. They also would make tests fail in Python >= 3.12, as we catch warnings as errors.