### PR TITLE
Lazily import graphics modules

### DIFF
--- a/src/viperleed/gui/cli.py
+++ b/src/viperleed/gui/cli.py
@@ -11,16 +11,9 @@ __copyright__ = 'Copyright (c) 2019-2025 ViPErLEED developers'
 __created__ = '2020-01-11'
 __license__ = 'GPLv3+'
 
+from importlib import import_module
 from pathlib import Path
 import sys
-
-try:
-    import PyQt5.QtCore as qtc
-except ImportError:
-    pass
-else:
-    import PyQt5.QtGui as qtg
-    import PyQt5.QtWidgets as qtw
 
 from viperleed.cli_base import ViPErLEEDCLI
 from viperleed.gui.base import catch_gui_crash
@@ -28,9 +21,6 @@ from viperleed.gui.constants import LOGO
 from viperleed.gui.detect_graphics import has_graphics
 from viperleed.gui.detect_graphics import has_pyqt
 from viperleed.gui.helpers import resources_path
-
-if has_pyqt():
-    from viperleed.gui.selectplugin import ViPErLEEDSelectPlugin
 
 
 class ViPErLEEDGUICLI(ViPErLEEDCLI, cli_name='gui'):
@@ -95,6 +85,11 @@ def gui_main():
     Body of the functionality that invokes the ViPErLEED
     Graphical User Interface.
     """
+    (qtc,
+     qtg,
+     qtw,
+     plugin_selector) = import_graphics_modules()
+
     catch_gui_crash()
 
     print('Loading GUI...', flush=True, end='')
@@ -114,7 +109,20 @@ def gui_main():
         str(Path(font_path, 'cmunrm.otf').resolve())
         )
 
-    plugin_selector_window = ViPErLEEDSelectPlugin()
+    plugin_selector_window = plugin_selector()
     plugin_selector_window.show()
     print('Done', flush=True)
     return app.exec_()
+
+
+def import_graphics_modules():
+    """Dynamically import modules for graphical capability."""
+    if not has_pyqt():
+        raise ImportError('PyQt5 is not available.')
+    gui_select = import_module('viperleed.gui.selectplugin')
+    return (
+        import_module('PyQt5.QtCore'),  # Not graphics per-se
+        import_module('PyQt5.QtGui'),
+        import_module('PyQt5.QtWidgets'),
+        gui_select.ViPErLEEDSelectPlugin,
+        )

--- a/tests/calc/test_cli.py
+++ b/tests/calc/test_cli.py
@@ -57,8 +57,7 @@ def test_calc_never_loads_graphics(mocker):
                    for name, module in sys.modules.items()
                    if 'viperleed.gui' in name}
     graphics_modules = {}
-    for module_name in gui_modules:
-        module = sys.modules[module_name]
+    for module_name, module in gui_modules.items():
         members = dict(inspect.getmembers(module))
         unexpected = [
             gui_obj

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,10 +65,15 @@ def fixture_mock_gui(mocker):
     """Prevent the GUI from opening up."""
     if not has_pyqt():
         return  # Nothing to do here
-    mocker.patch('viperleed.gui.cli.ViPErLEEDSelectPlugin')
-    mocker.patch('viperleed.gui.cli.qtc')
-    mocker.patch('viperleed.gui.cli.qtg')
-    qtw = mocker.patch('viperleed.gui.cli.qtw')
+    mock_graphics_modules = {
+        'qtc': mocker.MagicMock(),
+        'qtg': mocker.MagicMock(),
+        'qtw': mocker.MagicMock(),
+        'ViPErLEEDSelectPlugin': mocker.MagicMock(),
+        }
+    mocker.patch('viperleed.gui.cli.import_graphics_modules',
+                 return_value=mock_graphics_modules.values())
+    qtw = mock_graphics_modules['qtw']
     qtw.QApplication.exec_.return_value = 0
 
 


### PR DESCRIPTION
Fixes the error message in #434. The root cause, however, will be fixed in a separate PR.

We were loading graphics-related modules on systems that had `PyQt5` installed even if they were not needed. The import happened when loading all known CLIs, and was because `gui.selectplugin` imports the main windows from the plugins too.