### PR TITLE
Add warnings in AVERAGE_BEAMS and BEAM_INCIDENCE docs

### DIFF
--- a/doc/content/calc/parameters/averagebeams.rst
+++ b/doc/content/calc/parameters/averagebeams.rst
@@ -6,6 +6,13 @@
 AVERAGE_BEAMS
 =============
 
+.. warning::
+   This parameter is currently parsed, but not fully functional. Turning beam
+   averaging off entirely performs as described below, but specifying a beam
+   incidence angle different from :ref:`BEAMINCIDENCE` does **not** affect beam
+   averaging. Averaging will be performed as if beam incidence was perpendicular
+   to the surface.
+
 AVERAGE_BEAMS can be used to turn averaging of symmetry-equivalent beams
 off, or to make it follow a different averaging scheme than would be 
 dictated by :ref:`BEAMINCIDENCE`. This can be useful to 

--- a/doc/content/calc/parameters/beamincidence.rst
+++ b/doc/content/calc/parameters/beamincidence.rst
@@ -47,6 +47,13 @@ polar angle theta, the second as the azimuth phi.
    (\ :math:`\phi`) relative to the coordinate system of the 
    :ref:`POSCAR` file.
 
+.. warning::
+   The beam incidence does currently **not** affect beam averaging. Averaging
+   will be performed as if beam incidence was perpendicular to the surface
+   unless otherwise specified. This can be circumvented by disabling averaging
+   using :ref:`AVERAGEBEAMS`, and ensuring that experimental beams are correctly
+   averaged, with labels identical to the ones in :ref:`IVBEAMS`.
+
 .. hint::
    -  In general, unless the experiment was performed at large off-normal 
       incidence (>2°), keeping the default value should lead to the correct 


### PR DESCRIPTION
Adds warnings to inform users that BEAM_INCIDENCE currently does not do what you would expect, and especially AVERAGE_BEAMS does not do what the documentation says.

Can be undone once #133 is resolved.

Closes #445 