### PR TITLE
Always re-normalize weights to sum to 1 when averaging beams

### DIFF
--- a/src/viperleed/calc/files/beams.py
+++ b/src/viperleed/calc/files/beams.py
@@ -33,11 +33,14 @@ logger = logging.getLogger(__name__)
 
 def averageBeams(beams, weights=None):
     """Takes a list of percentages and a list of lists of Beam objects.
-    Returns a new list of Beam objects with weighted averaged intensities."""
+    Returns a new list of Beam objects with weighted averaged intensities.
+    Weights will be renormalized such that they sum to 1."""
     if beams is None:
         raise ValueError("averageBeams: No beams passed.")
     if weights is None or len(weights) == 0:
-        weights = [1/len(beams)] * len(beams)
+        weights = np.repeat([1/len(beams)], len(beams))
+    else:
+        weights = np.array(weights) / sum(weights)
     avbeams = copy.deepcopy(beams[0])
     for (i, b) in enumerate(avbeams):
         if not all([beams[j][i].isEqual(b) for j in range(1, len(beams))]):

--- a/src/viperleed/calc/files/beams.py
+++ b/src/viperleed/calc/files/beams.py
@@ -40,7 +40,7 @@ def averageBeams(beams, weights=None):
     if weights is None or len(weights) == 0:
         _weights = np.repeat([1/len(beams)], len(beams))
     else:
-        _weights = np.array(weights) / sum(weights)
+        _weights = np.asarray(weights) / sum(weights)
     avbeams = copy.deepcopy(beams[0])
     for (i, b) in enumerate(avbeams):
         if not all([beams[j][i].isEqual(b) for j in range(1, len(beams))]):

--- a/src/viperleed/calc/files/beams.py
+++ b/src/viperleed/calc/files/beams.py
@@ -38,9 +38,9 @@ def averageBeams(beams, weights=None):
     if beams is None:
         raise ValueError("averageBeams: No beams passed.")
     if weights is None or len(weights) == 0:
-        weights = np.repeat([1/len(beams)], len(beams))
+        _weights = np.repeat([1/len(beams)], len(beams))
     else:
-        weights = np.array(weights) / sum(weights)
+        _weights = np.array(weights) / sum(weights)
     avbeams = copy.deepcopy(beams[0])
     for (i, b) in enumerate(avbeams):
         if not all([beams[j][i].isEqual(b) for j in range(1, len(beams))]):
@@ -55,9 +55,9 @@ def averageBeams(beams, weights=None):
             raise ValueError(_err)
             return []
         for en in b.intens:
-            b.intens[en] *= weights[0]
+            b.intens[en] *= _weights[0]
             for j in range(1, len(beams)):
-                b.intens[en] += beams[j][i].intens[en] * weights[j]
+                b.intens[en] += beams[j][i].intens[en] * _weights[j]
     return avbeams
 
 


### PR DESCRIPTION
Fixes #453

As @LutzHammer already suspected, the issue is caused by the "percentages" in SD.TL being taken as-is, without dividing by 100, here:
https://github.com/viperleed/viperleed/blob/2cefa8dac9fe16b0ef24cf4ec830c3e45dcfb468/src/viperleed/calc/sections/superpos.py#L196-L213

Rather than fixing it directly there, this PR edits `viperleed.calc.files.beams.averageBeams` to always re-normalize weights such that they sum to 1 before averaging. This should solve this type of issue more generally.