### PR TITLE
Robust R factor selection

### DIFF
--- a/doc/content/calc/parameters/rfactortype.rst
+++ b/doc/content/calc/parameters/rfactortype.rst
@@ -9,12 +9,31 @@ R_FACTOR_TYPE determines what definition of the |R factor| is used in
 |R-factor| calculations, including during the search. For details, see
 |R-factor| :ref:`calculation<r-factor_calculation>`.
 
-**Default:** 1
+**Default:** pendry
 
-**Allowed values:** 1 (Pendry), 2 (R2)
+**Allowed values:** pendry (1), r2 (2), zj (3), smooth (4)
 
 **Syntax:**
 
 ::
 
-   R_FACTOR_TYPE = 2
+   R_FACTOR_TYPE = smooth   ! equivalent: R_FACTOR_TYPE = 4
+   
+
+.. warning::
+    The "smooth" |R-factor| |RS| is currently only implemented for the
+    :ref:`sec_search` using the viperleed-jax :ref:`BACKEND`. All segments
+    except for the :ref:`sec_search` will default to |RP| when |RS| is picked,
+    printing a warning.
+
+.. todo::
+    Update once |RS| is supported in old TensErLEED.
+
+Changelog
+---------
+
+.. versionchanged:: 0.15.0
+   Added support for |RS|
+.. versionchanged:: 0.15.0
+   Accepts string definitions in addition to integers
+   

--- a/doc/content/calc/sections/r-factor_calculation.rst
+++ b/doc/content/calc/sections/r-factor_calculation.rst
@@ -107,13 +107,13 @@ file should already contain smoothed data.
 The "smooth" |R factor|
 ---------------------
 
-We have `recently introduced <https://arxiv.org/abs/2511.05448v1>`__ a modified
-|R factor| |RS|, calculated in a similar manner as |RP| but adapting the
-definition of the :math:`Y` functions to improve its behavior near intensity
+We have recently introduced a modified |R factor| |RS|
+:cite:p:`imreRSmooth2025`, calculated in a similar manner as |RP| but adapting
+the definition of the :math:`Y` functions to improve its behavior near intensity
 minima. This should improve convergence in the :ref:`sec_search`, in particular
 when using gradient-based methods as implemented in the viperleed-jax
 :ref:`BACKEND`. Comparing |RP| and |RS| on the same system will typically yield
-slightly lower values for |RS| by about 0.01.
+slightly lower values for |RS| on the order of 0.01.
 
 .. todo::
     Update this with more details and update the citation once the |RS| paper

--- a/doc/content/calc/sections/r-factor_calculation.rst
+++ b/doc/content/calc/sections/r-factor_calculation.rst
@@ -14,18 +14,25 @@ the |R factor| between the calculated and experimental |IV| curves.
 As the comparison of two curves is not an unambiguous task, multiple |R factor|
 implementations exist. The :ref:`RFACTORTYPE` parameter can be set in
 the :ref:`PARAMETERS` file to choose between
-Pendry's |R factor| |RP| :cite:p:`pendryReliabilityFactorsLEED1980`
-and :math:`R_2` :cite:p:`spornAccuracyQuantitativeLEED1998`:
+Pendry's |R factor| |RP| :cite:p:`pendryReliabilityFactorsLEED1980`,
+:math:`R_2` :cite:p:`spornAccuracyQuantitativeLEED1998`
+and a new "smooth" |R factor| |RS| :cite:p:`imreRSmooth2025`:
 
 -   |RP| compares the logarithmic derivatives of the |IV| data, using a fix
     for the divergence of the logarithm when the intensity approaches zero.
 -   :math:`R_2` is based on the mean square difference of the |IV| curves
     (after appropriate scaling).
+-   |RS| is an improvement on |RP|, which behaves better near intensity minima,
+    resulting in fewer local |R factor| minima and better gradients.
 
 .. note::
     Using |RP| is the **default setting** and highly encouraged since tests
     have shown that it leads to better results than :math:`R_2`
     :cite:p:`spornAccuracyQuantitativeLEED1998`.
+
+.. warning::
+    |RS| is currently only implemented for the :ref:`sec_search` using the
+    viperleed-jax :ref:`BACKEND`.
 
 .. _pendry_r:
 
@@ -96,6 +103,24 @@ file should already contain smoothed data.
     Using the :ref:`RFACTORSMOOTH` parameter for smoothing the experimental
     |IV| curves is discouraged, as the smoothing algorithm applied there is
     inferior to that used by the |IV|-curve editor.
+
+The "smooth" |R factor|
+---------------------
+
+We have `recently introduced <https://arxiv.org/abs/2511.05448v1>`__ a modified
+|R factor| |RS|, calculated in a similar manner as |RP| but adapting the
+definition of the :math:`Y` functions to improve its behavior near intensity
+minima. This should improve convergence in the :ref:`sec_search`, in particular
+when using gradient-based methods as implemented in the viperleed-jax
+:ref:`BACKEND`. Comparing |RP| and |RS| on the same system will typically yield
+slightly lower values for |RS| by about 0.01.
+
+.. todo::
+    Update this with more details and update the citation once the |RS| paper
+    is out.
+
+.. todo::
+    Update when |RS| is available for TensErLEED.
 
 .. [1] Notice that the Pendry |R factor| between two sets of beams is not the
        average of the |R factor|\ s between beam pairs, as sums over all beams

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1,3 +1,13 @@
+@misc{imreRSmooth2025,
+      title={An improved reliability factor for quantitative low-energy electron diffraction}, 
+      author={Imre, Alexander M. and Hammer, Lutz and Diebold, Ulrike and Riva, Michele and Schmid, Michael},
+      year={2025},
+      eprint={2511.05448},
+      archivePrefix={arXiv},
+      primaryClass={cond-mat.mtrl-sci},
+      url={https://arxiv.org/abs/2511.05448}, 
+}
+
 @article{kraushoferViPErLEEDPackageCalculation2025,
   title      = {{{ViPErLEED}} Package {{I}}: {{Calculation}} of {I(V)} Curves and Structural Optimization},
   shorttitle = {{{ViPErLEED}} Package {{I}}},

--- a/doc/substitutions.rst
+++ b/doc/substitutions.rst
@@ -20,6 +20,7 @@
 .. |R-factor|     replace:: :math:`R`\ -factor
 .. |R factor|     replace:: :math:`R` factor
 .. |RP|           replace:: :math:`R_\mathrm{P}`
+.. |RS|           replace:: :math:`R_\mathrm{S}`
 .. |SUPP|         replace:: :file:`SUPP`
 .. |V0i|          replace:: :math:`V_{0\mathrm{i}}`
 .. |V0r|          replace:: :math:`V_{0\mathrm{r}}`

--- a/src/viperleed/calc/classes/rparams/rparams.py
+++ b/src/viperleed/calc/classes/rparams/rparams.py
@@ -140,8 +140,8 @@ class Rparams:
                         'overbar': False, 'perpage': 2,
                         }
         self.RUN = self.get_default('RUN')        # what segments should be run
-        self.R_FACTOR_LEGACY = True # use old runtime-compiled R-factor calculation
-        self.R_FACTOR_TYPE = 1  # 1: Pendry, 2: R2, 3: Zanazzi-Jona
+        self.R_FACTOR_LEGACY = True
+        self.R_FACTOR_TYPE = 'pendry'  # Pendry R-factor by default
         self.R_FACTOR_SMOOTH = 0
         self.S_OVL = 0.3 # Muffin tin overlap parameter after Rundgren 2021, default is 0.3 - set or optimize in FD
         self.SCREEN_APERTURE = 110.

--- a/src/viperleed/calc/classes/rparams/special/r_factor_type.py
+++ b/src/viperleed/calc/classes/rparams/special/r_factor_type.py
@@ -1,0 +1,197 @@
+"""Module l_max of viperleed.calc.classes.rparams.special.
+
+Defines the LMax class, a convenience container for parameter LMAX.
+"""
+
+__authors__ = ('Alexander M. Imre (@amimre)',)
+__copyright__ = 'Copyright (c) 2019-2025 ViPErLEED developers'
+__created__ = '2025-11-11'
+__license__ = 'GPLv3+'
+
+
+from .base import SpecialParameter, SpecialParameterError
+
+
+class RFactorTypeError(SpecialParameterError):
+    """Exception for RFactorType-related errors."""
+
+
+class RFactorType(SpecialParameter, param='R_FACTOR_TYPE'):
+    """Enum-like parameter for selecting the R-factor type.
+
+    This class provides a robust interface for specifying which
+    R-factor is used. It accepts both integer codes and a range of
+    string identifiers.
+
+    Canonical mapping:
+        1 → 'pendry'
+        2 → 'r2'
+        3 → 'zj'
+        4 → 'smooth'
+
+    Parameters
+    ----------
+    value : {int, str, RFactorType}
+        The value to parse. Integers 1–4 map directly to the canonical
+        names above. Strings are case-insensitive and may include any
+        of the registered synonyms.
+
+    Attributes
+    ----------
+    id : int
+        Integer code identifying the selected R-factor type.
+    name : str
+        Canonical string name of the selected R-factor type.
+
+    Notes
+    -----
+    This class is automatically registered under the parameter name
+    ``'R_FACTOR_TYPE'`` via :meth:`SpecialParameter.__init_subclass__`.
+    """
+
+    # Define synonyms for matching
+    _ALIASES = {
+        'pendry': ['pendry_r', 'rp', 'pendry', 'pend', 'p'],
+        'R2': ['r2', 'r squared'],
+        'zj': ['zanazzi jona', 'zanazzi-jona', 'zanazzi_jona', 'zannazi', 'z'],
+        'smooth': [
+            'smoothed',
+            'smooth pendry',
+            'smooth-pendry',
+            'schmid',
+            's',
+        ],
+    }
+
+    _CODE_TO_NAME = {
+        1: 'pendry',
+        2: 'r2',
+        3: 'zj',
+        4: 'smooth',
+    }
+
+    # Constant integer codes
+    PENDRY = 1
+    R2 = 2
+    ZJ = 3
+    SMOOTH = 4
+
+    # Build reverse lookup including aliases
+    _NAME_TO_CODE = None  # filled below
+
+    def __init__(self, value):
+        r_fac_id, name = self._coerce(value)
+        self.id = r_fac_id
+        self.name = name
+
+    # --------- construction helpers ---------
+    @classmethod
+    def from_value(cls, value):
+        """Create an instance from ``value``.
+
+        Parameters
+        ----------
+        value : {int, str, RFactorType}
+            Input to parse into an R-factor type.
+
+        Returns
+        -------
+        RFactorType
+            Parsed instance.
+        """
+        return cls(value)
+
+    @classmethod
+    def _build_reverse_maps(cls):
+        """(Re)build the normalized name->code map including aliases."""
+        name_to_code = {}
+        # canonical names
+        for code, canon in cls._CODE_TO_NAME.items():
+            name_to_code[cls._norm_name(canon)] = code
+        # aliases
+        for canon, aliases in cls._ALIASES.items():
+            code = next(
+                k
+                for k, v in cls._CODE_TO_NAME.items()
+                if v.lower() == canon.lower()
+            )
+            for a in aliases:
+                name_to_code[cls._norm_name(a)] = code
+        cls._NAME_TO_CODE = name_to_code
+
+    @classmethod
+    def _coerce(cls, value):
+        """Parse input into (code, name)."""
+        if cls._NAME_TO_CODE is None:
+            cls._build_reverse_maps()
+
+        # Already an instance
+        if isinstance(value, cls):
+            return value.id, value.name
+
+        # Int-like
+        if isinstance(value, int):
+            try:
+                name = cls._CODE_TO_NAME[value]
+            except KeyError:
+                msg = f'Invalid R_FACTOR_TYPE code: {value}'
+                raise RFactorTypeError(msg) from None
+            return value, name
+
+        # String-like
+        if isinstance(value, str):
+            v = value.strip()
+            if v.isdigit():
+                code = int(v)
+                try:
+                    name = cls._CODE_TO_NAME[code]
+                except KeyError:
+                    msg = f'Invalid R_FACTOR_TYPE code: {value}'
+                    raise RFactorTypeError(msg) from None
+                return code, name
+            # name/alias
+            key = cls._norm_name(v)
+            try:
+                code = cls._NAME_TO_CODE[key]
+            except KeyError:
+                allowed = ', '.join(cls._CODE_TO_NAME.values())
+                msg = f"Invalid R_FACTOR_TYPE name: '{value}'. Allowed: {allowed}"
+                raise RFactorTypeError(msg) from None
+            return code, cls._CODE_TO_NAME[code]
+
+        msg = f'Cannot parse R_FACTOR_TYPE from {type(value).__name__}: {value!r}'
+        raise TypeError(msg)
+
+    @staticmethod
+    def _norm_name(input_str):
+        """Normalize a name for robust matching."""
+        # unify type & whitespace
+        output_str = input_str.strip().casefold()
+        # replace common separators
+        return (
+            output_str.replace('²', '2')
+            .replace('^', '')
+            .replace('_', '')
+            .replace('-', '')
+            .replace(' ', '')
+        )
+
+    def __repr__(self):
+        """Return a representation string of this RFactorType."""
+        return f"RFactorType(code={self.id}, name='{self.name}')"
+
+    def __str__(self):
+        """Return a string version of this RFactorType."""
+        return self.name
+
+    def __int__(self):
+        """Return the integer code of this RFactorType."""
+        return self.id
+
+    def __eq__(self, other):
+        """Compare with int, str, or RFactorType."""
+        try:
+            r_fac_id, _ = self._coerce(other)
+        except (TypeError, ValueError):
+            return NotImplemented
+        return self.id == r_fac_id

--- a/src/viperleed/calc/files/iorfactor.py
+++ b/src/viperleed/calc/files/iorfactor.py
@@ -401,6 +401,11 @@ def writeWEXPEL(sl, rp, theobeams, filename="WEXPEL", for_error=False):
     Returns
     -------
     None.
+
+    Raises
+    ------
+    RfactorError
+        If selected R-factor type is not supported by TensErLEED
     """
     (_, theo_range,
      iv_shift, vincr) = prepare_rfactor_energy_ranges(rp, theobeams,
@@ -468,12 +473,19 @@ def writeWEXPEL(sl, rp, theobeams, filename="WEXPEL", for_error=False):
         output += '\n'
     output += '&NL2\n'
     output += ' NSSK=    0,\n'
-    if rp.R_FACTOR_TYPE == 1:
-        output += ' WR=      0.,0.,1.,\n'  # Pendry
-    elif rp.R_FACTOR_TYPE == 2:
-        output += ' WR=      1.,0.,0.,\n'  # R2
+    if str(rp.R_FACTOR_TYPE) == 'pendry':
+        output += ' WR=      0.,0.,1.,\n'
+    elif str(rp.R_FACTOR_TYPE) == 'r2':
+        output += ' WR=      1.,0.,0.,\n'
+    elif str(rp.R_FACTOR_TYPE) == 'zj':
+        output += ' WR=      0.,1.,0.,\n'
     else:
-        output += ' WR=      0.,1.,0.,\n'  # Zanazzi-Jona
+        msg = (
+            f'R factor type {rp.R_FACTOR_TYPE} not supported by '
+            'TensErLEED backend.'
+        )
+        logger.error(msg)
+        raise RfactorError(msg)
     output += '''\
  &END
  &NL3

--- a/src/viperleed/calc/files/iosearch.py
+++ b/src/viperleed/calc/files/iosearch.py
@@ -606,8 +606,10 @@ C MNATOMS IS RELICT FROM OLDER VERSIONS
     output += (formatter['int'].write([0]).ljust(16) + "initialisation for "
                "random number generator - 0: use system time, 1,...: use"
                " init\n")
-    output += (formatter['int'].write([rp.R_FACTOR_TYPE]).ljust(16)
-               + "1: use RPe -- 2: use R2\n")
+    output += (
+        formatter['int'].write([int(rp.R_FACTOR_TYPE)]).ljust(16)
+        + '1: use RPe -- 2: use R2\n'
+    )
     output += (formatter['int'].write([rp.SEARCH_BEAMS]).ljust(16)
                + "Optimization of which beam group do you want? "
                "(0=Aver,1=Int,2=Half)\n")

--- a/src/viperleed/calc/files/parameters/interpret.py
+++ b/src/viperleed/calc/files/parameters/interpret.py
@@ -28,11 +28,13 @@ import re
 import numpy as np
 
 from viperleed import __version__
+from viperleed.calc.classes.rparams.special.base import SpecialParameterError
 from viperleed.calc.classes.rparams.special.energy_range import EnergyRange
 from viperleed.calc.classes.rparams.special.energy_range import IVShiftRange
 from viperleed.calc.classes.rparams.special.energy_range import TheoEnergies
 from viperleed.calc.classes.rparams.special.layer_cuts import LayerCuts
 from viperleed.calc.classes.rparams.special.l_max import LMax
+from viperleed.calc.classes.rparams.special.r_factor_type import RFactorType
 from viperleed.calc.classes.rparams.special.search_cull import SearchCull
 from viperleed.calc.classes.rparams.special.symmetry_eps import SymmetryEps
 from viperleed.calc.classes.rparams.special.max_tl_displacement import (
@@ -99,30 +101,32 @@ _SIMPLE_BOOL_PARAMS = {
 # automatically. Key is parameter name, value is a NumericBounds
 _SIMPLE_NUMERICAL_PARAMS = {
     # Positive-only integers
-    'BULKDOUBLING_MAX' : POSITIVE_INT,
-    'N_CORES' : POSITIVE_INT,
-    'SEARCH_MAX_GEN' : POSITIVE_INT,
-    'TENSOR_INDEX' : POSITIVE_INT,
+    'BULKDOUBLING_MAX': POSITIVE_INT,
+    'N_CORES': POSITIVE_INT,
+    'SEARCH_MAX_GEN': POSITIVE_INT,
+    'TENSOR_INDEX': POSITIVE_INT,
     # Positive-only floats
-    'T_DEBYE' : POSITIVE_FLOAT,
-    'T_EXPERIMENT' : POSITIVE_FLOAT,
-    'V0_IMAG' : POSITIVE_FLOAT,
+    'T_DEBYE': POSITIVE_FLOAT,
+    'T_EXPERIMENT': POSITIVE_FLOAT,
+    'V0_IMAG': POSITIVE_FLOAT,
     # Other floats
-    'V0_Z_ONSET' : NumericBounds(),
-    'ATTENUATION_EPS' : NumericBounds(range_=(1e-6, 1),
-                                      accept_limits=(True, False)),
-    'BULKDOUBLING_EPS' : NumericBounds(range_=(1e-4, None),
-                                       out_of_range_event='coerce'),
-    'BULK_LIKE_BELOW': NumericBounds(range_=(0, 1),
-                                     accept_limits=(False, False)),
-    'SCREEN_APERTURE' : NumericBounds(range_=(0, 180)),
+    'V0_Z_ONSET': NumericBounds(),
+    'ATTENUATION_EPS': NumericBounds(
+        range_=(1e-6, 1), accept_limits=(True, False)
+    ),
+    'BULKDOUBLING_EPS': NumericBounds(
+        range_=(1e-4, None), out_of_range_event='coerce'
+    ),
+    'BULK_LIKE_BELOW': NumericBounds(
+        range_=(0, 1), accept_limits=(False, False)
+    ),
+    'SCREEN_APERTURE': NumericBounds(range_=(0, 180)),
     # Other integers
-    'HALTING' : NumericBounds(type_=int, range_=(1, 3)),
-    'N_BULK_LAYERS' : NumericBounds(type_=int, range_=(1, 2)),
-    'R_FACTOR_SMOOTH' : NumericBounds(type_=int, range_=(0, 999)),
-    'R_FACTOR_TYPE' : NumericBounds(type_=int, range_=(1, 2)),
-    'ZIP_COMPRESSION_LEVEL' : NumericBounds(type_=int, range_=(0, 9))
-    }
+    'HALTING': NumericBounds(type_=int, range_=(1, 3)),
+    'N_BULK_LAYERS': NumericBounds(type_=int, range_=(1, 2)),
+    'R_FACTOR_SMOOTH': NumericBounds(type_=int, range_=(0, 999)),
+    'ZIP_COMPRESSION_LEVEL': NumericBounds(type_=int, range_=(0, 9)),
+}
 
 
 # parameters that can be optimized in FD optimization
@@ -1524,6 +1528,15 @@ class ParameterInterpreter:  # pylint: disable=too-many-public-methods
             self.rpars.SEARCH_BEAMS = 2
         else:
             raise ParameterValueError(param, value)
+
+    def interpret_r_factor_type(self, assignment):
+        """Assign parameter R_FACTOR_TYPE."""
+        param = 'R_FACTOR_TYPE'
+        self._ensure_simple_assignment(assignment)
+        try:
+            self.rpars.R_FACTOR_TYPE = RFactorType(assignment.value)
+        except SpecialParameterError as err:
+            raise ParameterValueError(param, assignment.value) from err
 
     def interpret_search_convergence(self, assignment, is_updating=False):      # TODO: Issue #139
         """Interpret SEARCH_CONVERGENCE parameter.

--- a/src/viperleed/calc/sections/errorcalc.py
+++ b/src/viperleed/calc/sections/errorcalc.py
@@ -129,7 +129,7 @@ def errorcalc(sl, rp):
 
     # Inform user that statistical error estimates are only available
     # for Pendry R-factor.
-    if rp.R_FACTOR_TYPE != 1:
+    if str(rp.R_FACTOR_TYPE) != 'pendry':
         logger.info("Estimates for statistical uncertainties "
                     "of parameters are only available for the Pendry "
                     "R-factor.")

--- a/src/viperleed/calc/sections/rfactor.py
+++ b/src/viperleed/calc/sections/rfactor.py
@@ -127,7 +127,7 @@ def _fetch_and_check_spectra(rp, index, name):
 
 def run_new_rfactor(sl, rp, for_error, name, theobeams, expbeams):
     logger.debug("Using new R-factor calculation. This is still experimental!")
-    which_r = rp.R_FACTOR_TYPE
+    which_r = int(rp.R_FACTOR_TYPE)
 
     if which_r == 1:
         n_derivs = 1

--- a/src/viperleed/calc/vlj/search.py
+++ b/src/viperleed/calc/vlj/search.py
@@ -105,6 +105,9 @@ def vlj_search(slab, rpars):
     # log the parameter space
     logger.debug(str(parameter_space))
 
+    # set the R-factor type
+    calculator.set_rfactor_type(str(rpars.R_FACTOR_TYPE))
+
     # (try to) export the tree view of the parameter space to a PDF file
     try:
         parameter_space.export_tree_view(

--- a/tests/calc/classes/rparams/special/test_r_factor_type.py
+++ b/tests/calc/classes/rparams/special/test_r_factor_type.py
@@ -1,0 +1,16 @@
+"""Tests for viperleed.calc.classes.rparams.special.r_factor_type."""
+
+__authors__ = ('Alexander M. Imre (@amimre)',)
+__copyright__ = 'Copyright (c) 2019-2025 ViPErLEED developers'
+__created__ = '2025-11-11'
+__license__ = 'GPLv3+'
+
+
+from viperleed.calc.classes.rparams.special.r_factor_type import RFactorType
+
+
+def test_synonyms():
+    assert int(RFactorType('r 2')) == RFactorType.R2
+    assert int(RFactorType('Zanazzi Jona')) == RFactorType.ZJ
+    assert int(RFactorType('rp')) == RFactorType.PENDRY
+    assert int(RFactorType('smooth pendry')) == RFactorType.SMOOTH


### PR DESCRIPTION
This PR implements a new, more robust R factor selection and adds the option to use the new smooth R factor with the vipeleed-jax plugin.
As I wanted to add the option for the new R factor, I noticed that the current selection is rather basic and only supported integer selection of R factors.