### PR TITLE
Fallback on R_P for refcalc

### DIFF
--- a/src/viperleed/calc/files/iorfactor.py
+++ b/src/viperleed/calc/files/iorfactor.py
@@ -479,6 +479,13 @@ def writeWEXPEL(sl, rp, theobeams, filename="WEXPEL", for_error=False):
         output += ' WR=      1.,0.,0.,\n'
     elif str(rp.R_FACTOR_TYPE) == 'zj':
         output += ' WR=      0.,1.,0.,\n'
+    elif str(rp.R_FACTOR_TYPE) == 'smooth':
+        output += ' WR=      0.,0.,1.,\n'
+        logger.warning(
+            'Smooth R-factors are not yet supported outside of the search. '
+            'Falling back on Pendry R-factor. Resulting R-factors may differ '
+            'from those calculated during the search.'
+            )
     else:
         msg = (
             f'R factor type {rp.R_FACTOR_TYPE} not supported by '

--- a/src/viperleed/calc/sections/errorcalc.py
+++ b/src/viperleed/calc/sections/errorcalc.py
@@ -129,6 +129,7 @@ def errorcalc(sl, rp):
 
     # Inform user that statistical error estimates are only available
     # for Pendry R-factor.
+    # TODO: Update once R_S is available
     if str(rp.R_FACTOR_TYPE) != 'pendry':
         logger.info("Estimates for statistical uncertainties "
                     "of parameters are only available for the Pendry "


### PR DESCRIPTION
I already put into the docs in #492 that R_S would fall back on R_P when not available. The scenario is that someone wants to use R_S for the JAX-backend search, but sets e.g. `RUN = 1-3 1`. Without an automatic fallback, it would currently be impossible to do refcalc and search in the same job while using R_S in the search.

In the end I decided to do a minimal implementation, which does not cover e.g. error calculations. I put a todo in instead so we remember to enable it there once we have a FORTRAN-based R_S.