### PR TITLE
No error for requested deltas in JAX backend

### DIFF
--- a/src/viperleed/calc/sections/deltas.py
+++ b/src/viperleed/calc/sections/deltas.py
@@ -358,11 +358,13 @@ def deltas(sl, rp, subdomain=False):
     # During normal operation deltas should never be called with the
     # viperleed-jax backend, but for API compatibility we still check for it.
     if rp.BACKEND["search"] == SearchBackend.VLJ:
-        raise RuntimeError(
+        logger.warning(
             'Delta calculations are not supported with the viperleed-jax '
-            'backend. To sample amplitude changes use the '
+            'backend. Since they are not required for the search, they will '
+            'be skipped. To sample amplitude changes explicitly use the '
             'TensorCalculator.delta_amplitudes() method from the API instead.'
         )
+        return
 
     if rp.domainParams:
         deltas_domains(rp)

--- a/src/viperleed/calc/sections/errorcalc.py
+++ b/src/viperleed/calc/sections/errorcalc.py
@@ -11,6 +11,7 @@ __license__ = 'GPLv3+'
 import logging
 import os
 
+from viperleed.calc.classes.search_backends import SearchBackend
 from viperleed.calc.classes.r_error import R_Error
 from viperleed.calc.classes.searchpar import SearchPar
 from viperleed.calc.files import ioerrorcalc
@@ -30,8 +31,17 @@ def errorcalc(sl, rp):
         # TODO!! requested by Tilman!!
         # !!! Should be straightforward. Just take the beams from other domains
         # as constant (from refcalc), vary for the one domain as always
-        logger.error("Error calculation not implemented for multiple domains.")
-        return
+        raise NotImplementedError(
+            "Error calculation are not implemented for multiple domains."
+            )
+
+    if rp.BACKEND["search"] == SearchBackend.VLJ:
+        # TODO - straightforward to implement
+        raise NotImplementedError(
+            'Error calculations are not implemented with the viperleed-jax '
+            'backend. To sample amplitude changes explicitly use the '
+            'TensorCalculator.delta_amplitudes() method from the API instead.'
+            )
 
     if rp.best_v0r is None:
         logger.info("Error calculation called without a stored inner "


### PR DESCRIPTION
Ignore request for deltas if e.g. RUN=1-3, only warn, as discussed in #331. However, *do* raise an error if error calculations are requested, since those are actually not implemented and would fail with a non-helpful error message.