### PR TITLE
Disable visual ROI selection

### DIFF
--- a/src/viperleed/gui/measure/camera/abc.py
+++ b/src/viperleed/gui/measure/camera/abc.py
@@ -512,9 +512,9 @@ class CameraABC(DeviceABC):
         Returns
         -------
         tuple
-            Returns an empty tuple if the value in the settings is
-            'None' or if any error occurred while trying to interpret
-            the setting.
+            Returns an empty tuple if any error occurred while trying to
+            interpret the setting, or the full ROI if the value in the
+            settings is 'None'.
 
             Otherwise the following elements are returned:
             roi_x, roi_y : int

--- a/src/viperleed/gui/measure/camera/abc.py
+++ b/src/viperleed/gui/measure/camera/abc.py
@@ -550,6 +550,12 @@ class CameraABC(DeviceABC):
         _, size_max, *_ = limits = self.get_roi_size_limits()
         full_roi = 0, 0, *size_max
 
+        roi_str = self.settings.get('camera_settings', 'roi', fallback='_')
+        roi_str = roi_str.lower()
+        if roi_str == 'none':
+            self.settings.set('camera_settings', 'roi', 'None')
+            return full_roi
+
         if not self.__is_valid_roi(roi, limits):
             self.emit_error(QObjectSettingsErrors.INVALID_SETTINGS,
                             'camera_settings/roi', '\nInfo: ROI is invalid. '

--- a/src/viperleed/gui/measure/widgets/cameraviewer.py
+++ b/src/viperleed/gui/measure/widgets/cameraviewer.py
@@ -45,7 +45,7 @@ from viperleed.gui.widgets.lib import screen_fraction
 
 _RED_BORDER_WIDTH = 3  # pixels
 _UNIQUE = qtc.Qt.UniqueConnection
-_ROI_RECT_ACTIVE = False # Whether the ROI rectangle is displayed or not.
+_ROI_RECT_ACTIVE = False  # Whether the ROI rectangle is displayed or not.
 
 # Each entry is ("short_name", default_value, "long name", always_active)
 # Those with an empty long name will not be added as context

--- a/src/viperleed/gui/measure/widgets/cameraviewer.py
+++ b/src/viperleed/gui/measure/widgets/cameraviewer.py
@@ -45,7 +45,7 @@ from viperleed.gui.widgets.lib import screen_fraction
 
 _RED_BORDER_WIDTH = 3  # pixels
 _UNIQUE = qtc.Qt.UniqueConnection
-_ROI_RECT_ACTIVE = False  # Whether the ROI rectangle is displayed or not.
+_ROI_RECT_ACTIVE = False  # TEMPORARY: ROI rectangle feature is disabled due to bugs. Re-enable this flag when the bugs are fixed.
 _ALLOW_ROI_TEXT = "Allow setting ROI"
 
 # Each entry is ("short_name", default_value, "long name", always_active)

--- a/src/viperleed/gui/measure/widgets/cameraviewer.py
+++ b/src/viperleed/gui/measure/widgets/cameraviewer.py
@@ -495,10 +495,10 @@ class CameraViewer(qtw.QScrollArea):
         if not self.roi_visible or self.__mouse_button != qtc.Qt.LeftButton:
             super().mouseMoveEvent(event)
             return
-        mouse_pos = self.roi.parent().mapFromGlobal(event.globalPos())
-        self.roi.setGeometry(qtc.QRect(self.roi.origin, mouse_pos))
-        if not self.roi.isVisible():
-            self.roi.show()
+        # mouse_pos = self.roi.parent().mapFromGlobal(event.globalPos())        # TODO: enable after ROI was fixed
+        # self.roi.setGeometry(qtc.QRect(self.roi.origin, mouse_pos))
+        # if not self.roi.isVisible():
+            # self.roi.show()
 
     def mousePressEvent(self, event):    # pylint: disable=invalid-name
         """Extend mousePressEvent to begin drawing a ROI."""
@@ -931,8 +931,8 @@ class CameraViewer(qtw.QScrollArea):
         new_roi = (roi_x - offs_x, roi_y - offs_y, roi_w, roi_h)
         if new_roi != self.roi.image_coordinates:
             self.roi.image_coordinates = new_roi
-        if not self.roi.isVisible():
-            self.roi.show()
+        # if not self.roi.isVisible():                                          # TODO: enable after ROI was fixed
+            # self.roi.show()
 
     def __on_settings_changed(self):
         """React to a user press of "Apply"/"Ok" in the settings dialog."""
@@ -1090,7 +1090,7 @@ class CameraViewer(qtw.QScrollArea):
             else:
                 enable = active or self.interactions_enabled
             action.setEnabled(enable)
-            if "ROI" in action.text():                                          # TODO: remove once visual ROI selection is fixed
+            if action.text() == "Allow setting ROI":                            # TODO: remove once visual ROI selection is fixed
                 action.setEnabled(False)
 
     def __update_frame_style(self):

--- a/src/viperleed/gui/measure/widgets/cameraviewer.py
+++ b/src/viperleed/gui/measure/widgets/cameraviewer.py
@@ -45,6 +45,7 @@ from viperleed.gui.widgets.lib import screen_fraction
 
 _RED_BORDER_WIDTH = 3  # pixels
 _UNIQUE = qtc.Qt.UniqueConnection
+_ROI_RECT_ACTIVE = False # Whether the ROI rectangle is displayed or not.
 
 # Each entry is ("short_name", default_value, "long name", always_active)
 # Those with an empty long name will not be added as context
@@ -495,10 +496,12 @@ class CameraViewer(qtw.QScrollArea):
         if not self.roi_visible or self.__mouse_button != qtc.Qt.LeftButton:
             super().mouseMoveEvent(event)
             return
-        # mouse_pos = self.roi.parent().mapFromGlobal(event.globalPos())        # TODO: enable after ROI was fixed
-        # self.roi.setGeometry(qtc.QRect(self.roi.origin, mouse_pos))
-        # if not self.roi.isVisible():
-            # self.roi.show()
+        if not _ROI_RECT_ACTIVE:
+            return
+        mouse_pos = self.roi.parent().mapFromGlobal(event.globalPos())
+        self.roi.setGeometry(qtc.QRect(self.roi.origin, mouse_pos))
+        if not self.roi.isVisible():
+            self.roi.show()
 
     def mousePressEvent(self, event):    # pylint: disable=invalid-name
         """Extend mousePressEvent to begin drawing a ROI."""
@@ -931,8 +934,8 @@ class CameraViewer(qtw.QScrollArea):
         new_roi = (roi_x - offs_x, roi_y - offs_y, roi_w, roi_h)
         if new_roi != self.roi.image_coordinates:
             self.roi.image_coordinates = new_roi
-        # if not self.roi.isVisible():                                          # TODO: enable after ROI was fixed
-            # self.roi.show()
+        if _ROI_RECT_ACTIVE and not self.roi.isVisible():
+            self.roi.show()
 
     def __on_settings_changed(self):
         """React to a user press of "Apply"/"Ok" in the settings dialog."""
@@ -1090,7 +1093,7 @@ class CameraViewer(qtw.QScrollArea):
             else:
                 enable = active or self.interactions_enabled
             action.setEnabled(enable)
-            if action.text() == "Allow setting ROI":                            # TODO: remove once visual ROI selection is fixed
+            if action.text() == "Allow setting ROI" and not _ROI_RECT_ACTIVE:
                 action.setEnabled(False)
 
     def __update_frame_style(self):

--- a/src/viperleed/gui/measure/widgets/cameraviewer.py
+++ b/src/viperleed/gui/measure/widgets/cameraviewer.py
@@ -46,12 +46,13 @@ from viperleed.gui.widgets.lib import screen_fraction
 _RED_BORDER_WIDTH = 3  # pixels
 _UNIQUE = qtc.Qt.UniqueConnection
 _ROI_RECT_ACTIVE = False  # Whether the ROI rectangle is displayed or not.
+_ALLOW_ROI_TEXT = "Allow setting ROI"
 
 # Each entry is ("short_name", default_value, "long name", always_active)
 # Those with an empty long name will not be added as context
 # menu entries, and will thus not be editable by the user
 _DEFAULT_FLAGS = (
-    ("roi_visible", True, "Allow setting ROI", False),
+    ("roi_visible", True, _ALLOW_ROI_TEXT, False),
     ("show_auto", True, "Show on new frames", False),
     ("stop_on_close", True, "Stop camera when closed", False),
     ("auto_contrast", False, "Auto-adjust contrast", True),
@@ -1093,7 +1094,7 @@ class CameraViewer(qtw.QScrollArea):
             else:
                 enable = active or self.interactions_enabled
             action.setEnabled(enable)
-            if action.text() == "Allow setting ROI" and not _ROI_RECT_ACTIVE:
+            if action.text() == _ALLOW_ROI_TEXT and not _ROI_RECT_ACTIVE:
                 action.setEnabled(False)
 
     def __update_frame_style(self):

--- a/src/viperleed/gui/measure/widgets/cameraviewer.py
+++ b/src/viperleed/gui/measure/widgets/cameraviewer.py
@@ -1090,6 +1090,8 @@ class CameraViewer(qtw.QScrollArea):
             else:
                 enable = active or self.interactions_enabled
             action.setEnabled(enable)
+            if "ROI" in action.text():                                          # TODO: remove once visual ROI selection is fixed
+                action.setEnabled(False)
 
     def __update_frame_style(self):
         """Pick frame style depending on whether the image is saturated."""


### PR DESCRIPTION
Visual ROI selection is bugged, so it will be disabled for now. This will be undone once we fixed the ROI.
Fix bug when using None as ROI value. (Would not apply full ROI the first time the CameraViewer was opened with None as ROI value.)