### PR TITLE
Retry IC_StartLive

### DIFF
--- a/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
+++ b/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
@@ -815,7 +815,7 @@ class WindowsCamera:
         if not self.is_running or not self.trigger_enabled:
             return
         self.pause()
-        for i in range(0,5):
+        for _ in range(5):
             try:
                 self._dll_start_live(self.__handle, False)
             except ImagingSourceError:

--- a/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
+++ b/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
@@ -64,6 +64,8 @@ c_float_p = POINTER(c_float)
 c_long_p = POINTER(c_long)
 c_int_p = POINTER(c_int)
 
+BURST_RETRIES = 5
+
 
 def get_dll_path():
     """Return the path to the dll files."""
@@ -815,7 +817,7 @@ class WindowsCamera:
         if not self.is_running or not self.trigger_enabled:
             return
         self.pause()
-        for _ in range(5):
+        for _ in range(BURST_RETRIES):
             try:
                 self._dll_start_live(self.__handle, False)
             except ImagingSourceError:

--- a/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
+++ b/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
@@ -413,7 +413,7 @@ class WindowsCamera:
 
         return min_rate, max_rate
 
-    _dll_get_frame_rate =  _dll.IC_GetFrameRate
+    _dll_get_frame_rate = _dll.IC_GetFrameRate
     _dll_get_frame_rate.restype = c_float
     _dll_get_frame_rate.argtypes = (GrabberHandlePtr,)
     _dll_get_frame_rate.errcheck = check_dll_return('>0')
@@ -815,7 +815,15 @@ class WindowsCamera:
         if not self.is_running or not self.trigger_enabled:
             return
         self.pause()
-        self._dll_start_live(self.__handle, False)
+        for i in range(0,5):
+            try:
+                self._dll_start_live(self.__handle, False)
+            except ImagingSourceError:
+                # Failed, try again.
+                pass
+            else:
+                # Succeeded, no need to repeat.
+                return
 
     _dll_close_device = _dll.IC_CloseVideoCaptureDevice
     _dll_close_device.restype = None  # Returns void

--- a/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
+++ b/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
@@ -64,8 +64,7 @@ c_float_p = POINTER(c_float)
 c_long_p = POINTER(c_long)
 c_int_p = POINTER(c_int)
 
-# Number of retries for burst operations; empirically, a single retry
-# has been sufficient, so keep this low to fail fast and aid diagnostics.
+# Number of retries for burst operations; so far one retry has been sufficient
 BURST_RETRIES = 3
 
 

--- a/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
+++ b/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
@@ -64,7 +64,9 @@ c_float_p = POINTER(c_float)
 c_long_p = POINTER(c_long)
 c_int_p = POINTER(c_int)
 
-BURST_RETRIES = 5
+# Number of retries for burst operations; empirically, a single retry
+# has been sufficient, so keep this low to fail fast and aid diagnostics.
+BURST_RETRIES = 3
 
 
 def get_dll_path():

--- a/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
+++ b/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
@@ -824,6 +824,8 @@ class WindowsCamera:
             else:
                 # Succeeded, no need to repeat.
                 return
+        raise ImagingSourceError('The camera was unable to acquire '
+                                 'images in burst mode.')
 
     _dll_close_device = _dll.IC_CloseVideoCaptureDevice
     _dll_close_device.restype = None  # Returns void

--- a/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
+++ b/src/viperleed/gui/measure/camera/drivers/imagingsource/tisgrabber.py
@@ -826,8 +826,8 @@ class WindowsCamera:
             else:
                 # Succeeded, no need to repeat.
                 return
-        raise ImagingSourceError('The camera was unable to acquire '
-                                 'images in burst mode.')
+        raise ImagingSourceError('The camera was unable to restart after '
+                                 'aborting burst mode.')
 
     _dll_close_device = _dll.IC_CloseVideoCaptureDevice
     _dll_close_device.restype = None  # Returns void


### PR DESCRIPTION
The camera may sometimes raise an error during IC_StartLive. (Even though the device is ready according to IC_IsDevValid.) In that case retry. So far a single retry was always enough.