### PR TITLE
Debug search loops

### DIFF
--- a/src/viperleed/calc/files/new_displacements/file.py
+++ b/src/viperleed/calc/files/new_displacements/file.py
@@ -69,7 +69,8 @@ class DisplacementsFile(NodeMixin):
         """
         self._child_id = 0
         for child in self.children:
-            child.reset_iterator()
+            if isinstance(child, LoopBlock):
+                child.reset_iterator()
 
     @property
     def offsets(self):

--- a/src/viperleed/calc/files/new_displacements/file.py
+++ b/src/viperleed/calc/files/new_displacements/file.py
@@ -62,6 +62,15 @@ class DisplacementsFile(NodeMixin):
         if not self._has_been_read:
             raise ValueError('File has not been read yet. Call read() first.')
 
+    def reset_iterator(self):
+        """
+        Reset to the beginning of the displacement file, e.g. when search
+        repeats after a new reference calculation.
+        """
+        self._child_id = 0
+        for child in self.children:
+            child.reset_iterator()
+
     @property
     def offsets(self):
         """Return the OFFSETS block if present, else None."""

--- a/src/viperleed/calc/files/new_displacements/segments.py
+++ b/src/viperleed/calc/files/new_displacements/segments.py
@@ -281,7 +281,8 @@ class LoopBlock(DisplacementsSegmentABC):
         """
         self._current_child_id = 0
         for child in self.children:
-            child.reset_iterator()
+            if isinstance(child, LoopBlock):
+                child.reset_iterator()
 
     @staticmethod
     def is_my_header_line(line):

--- a/src/viperleed/calc/files/new_displacements/segments.py
+++ b/src/viperleed/calc/files/new_displacements/segments.py
@@ -274,6 +274,15 @@ class LoopBlock(DisplacementsSegmentABC):
         self._current_child_id = 0
         self._subsegments = (SearchBlock, LoopBlock)
 
+    def reset_iterator(self):
+        """
+        Reset to the beginning of the displacement file, e.g. when search
+        repeats after a new reference calculation.
+        """
+        self._current_child_id = 0
+        for child in self.children:
+            child.reset_iterator()
+
     @staticmethod
     def is_my_header_line(line):
         """Loops are started by Loop start lines."""

--- a/src/viperleed/calc/sections/initialization.py
+++ b/src/viperleed/calc/sections/initialization.py
@@ -412,7 +412,7 @@ def initialization(sl, rp, subdomain=False):
         return
 
     # viperleed_jax Plugin related initialization
-    if rp.BACKEND['search'] == SearchBackend.VLJ:
+    if rp.BACKEND['search'] == SearchBackend.VLJ and 3 in rp.RUN:
         logger.debug("Initializing viperleed-jax backend")
 
         if mp.get_start_method() != 'spawn':
@@ -947,6 +947,7 @@ def _read_inputs_for_domain(domain, main_rpars):
     rpars.inherit_from(main_rpars, *inherited)
     # It is crucial that some others are identical:
     inherit_and_override = (
+        'BACKEND',
         'TL_VERSION',
         )
     rpars.inherit_from(main_rpars, *inherit_and_override, override=True)

--- a/src/viperleed/calc/sections/run_sections.py
+++ b/src/viperleed/calc/sections/run_sections.py
@@ -223,8 +223,15 @@ def run_section(index, sl, rp):
                 # check dependencies
                 check_vlj_dependencies()
 
-                # initialize the TensorLEED calculator
-                vlj_search(sl, rp)
+                # run the TensorLEED calculator; NO built-in loop,
+                #  stop when it returns StopIteration
+                while True:
+                    try:
+                        vlj_search(sl, rp)
+                    except StopIteration:
+                        break
+                # reset the iterator
+                rp.vlj_displacements.reset_iterator()
             else:
                 search.search(sl, rp)
         elif index == 31:


### PR DESCRIPTION
Makes JAX-backed search actually execute everything in `DISPLACEMENTS`, and resets the iterator in case search repeats in `RUN`, e.g. `RUN = 1 3 1 3 1`, such that in the second `search` segment everything in `DISPLACEMENTS` is done again.