### PR TITLE
fix: load SUPERLATTICE to main params

### DIFF
--- a/src/viperleed/calc/sections/initialization.py
+++ b/src/viperleed/calc/sections/initialization.py
@@ -502,6 +502,7 @@ def init_domains(rp):
     rp.pseudoSlab.ucell = largestDomain.slab.ucell.copy()
     rp.pseudoSlab.bulkslab = BulkSlab()
     rp.pseudoSlab.bulkslab.ucell = largestDomain.slab.bulkslab.ucell.copy()
+    rp.SUPERLATTICE = largestDomain.rpars.SUPERLATTICE.copy()
     # run beamgen for the whole system
     logger.info("Generating BEAMLIST...")                                       # TODO: this bit is largely repeated in the end of initialization
     calc_and_write_beamlist(copy.deepcopy(largestDomain.slab),


### PR DESCRIPTION
The SUPERLATTICE from domains needs to be copied to the main rparams object before generating the BEAMLIST; otherwise, the BEAMLIST will assume (1x1) and all fractional beams will be discarded.

Domain calculations are currently completely non-functional without this fix. This is confirmed to work [tested on hematite (012)-(2x1)].