### PR TITLE
fix: use work/PHASESHIFTS

### DIFF
--- a/src/viperleed/calc/vlj/search.py
+++ b/src/viperleed/calc/vlj/search.py
@@ -97,7 +97,7 @@ def vlj_search(slab, rpars):
         slab,
         rpars,
         tensor_path=tensor_path,
-        phaseshifts_path=rpars.paths.home / 'PHASESHIFTS',
+        phaseshifts_path=Path('PHASESHIFTS').resolve(),
     )
 
     # apply the parameter space to the calculator


### PR DESCRIPTION
Like the TensErLEED backend, it is good practice to only use files that are available in the work directory, not those from the directory where the calculation was started. Here an example why: Running a 1-3 calculation that re-creates the phaseshifts, would fail to find a `PHASESHIFTS` file in the home directory with a non-informative message.

My specific case: I had to recalculate the phaseshifts after adding new sites. In this case, the execution does not stop after initialization.