### PR TITLE
Update docs to point out positive V0i

### DIFF
--- a/doc/content/calc/parameters/v0_imag.rst
+++ b/doc/content/calc/parameters/v0_imag.rst
@@ -9,6 +9,10 @@ V0_IMAG defines the imaginary part of the inner potential (in electronvolts),
 which is combined with the real part :ref:`V0_REAL<MUFTIN>`. (The original
 equivalent Fortran parameters are VPI, VPIS, VPIO.)
 
+.. note::
+    Different sign conventions exist in literature; here, V0_IMAG is
+    always expected to be positive.
+
 **Default**: V0_IMAG = 4.5
 
 **Syntax**:


### PR DESCRIPTION
@schmid-iap pointed out that different sign conventions exist in literature, and the "physical" expectation would be for V0i to be negative. However, we only allow posivity floats. I briefly looked at the option to allow negative values and interpret them as positive, but in the end I think it's more confusing than to just document it.