### PR TITLE
Fix mandatory and missing settings check

### DIFF
--- a/src/viperleed/gui/measure/classes/settings.py
+++ b/src/viperleed/gui/measure/classes/settings.py
@@ -442,28 +442,32 @@ class ViPErLEEDSettings(AliasConfigParser):
                 raise TypeError(f'Invalid mandatory setting {setting}. with '
                                 f'length {length}. Expected length <= 3.')
 
+            # First, check if settings are broken without reporting yet.
             settings_broken = False
-            if not self.has_section(setting[0]):
+            section, option, admissible = tuple(setting) + (None,) * (3-length)
+            if not self.has_section(section):
                 settings_broken = True
-            elif length > 1 and not self.has_option(setting[0], setting[1]):
+            elif length > 1 and not self.has_option(section, option):
                 settings_broken = True
-            elif length > 2 and self[setting[0]][setting[1]] not in setting[2]:
+            elif length > 2 and self[section][option] not in admissible:
                 settings_broken = True
 
             if not settings_broken:
                 continue
 
+            # Then report broken settings. This two-step approach ensures
+            # the entire setting is reported regardless of which part failed.
             # (<section>,)
             if length == 1:
-                invalid_settings.append(setting[0])
+                invalid_settings.append(section)
                 continue
             # (<section>, <option>)
             if length == 2:
-                invalid_settings.append(f'{setting[0]}/{setting[1]}')
+                invalid_settings.append(f'{section}/{option}')
                 continue
             # (<section>, <option>, <admissible>)
             invalid_settings.append('/'.join(setting[:2]) + ' not one of ' +
-                                    ', '.join(setting[2]))
+                                    ', '.join(admissible))
         return invalid_settings
 
     def read(self, filenames, encoding=None):

--- a/src/viperleed/gui/measure/classes/settings.py
+++ b/src/viperleed/gui/measure/classes/settings.py
@@ -873,7 +873,7 @@ class SystemSettings(ViPErLEEDSettings):
         # We're missing settings. Let's add them back...
         for missing in invalid:
             # 1. Strip off the value-error suffix if present
-            clean_keys = missing.split(' not one of ')[0]
+            clean_keys, *_ = missing.split(' not one of ')
             if '/' in clean_keys:
                 section, option = clean_keys.split('/')
             else:

--- a/src/viperleed/gui/measure/classes/settings.py
+++ b/src/viperleed/gui/measure/classes/settings.py
@@ -437,32 +437,33 @@ class ViPErLEEDSettings(AliasConfigParser):
         """
         invalid_settings = []
         for setting in required_settings:
-            if not setting or len(setting) > 3:
-                raise TypeError(f'Invalid mandatory setting {setting}. '
-                                f'with length {len(setting)}. Expected '
-                                'length <= 3.')
+            length = len(setting)
+            if not setting or length > 3:
+                raise TypeError(f'Invalid mandatory setting {setting}. with '
+                                f'length {length}. Expected length <= 3.')
+
+            settings_broken = False
+            if not self.has_section(setting[0]):
+                settings_broken = True
+            elif length > 1 and not self.has_option(setting[0], setting[1]):
+                settings_broken = True
+            elif length > 2 and self[setting[0]][setting[1]] not in setting[2]:
+                settings_broken = True
+
+            if not settings_broken:
+                continue
 
             # (<section>,)
-            if not self.has_section(setting[0]):
+            if length == 1:
                 invalid_settings.append(setting[0])
                 continue
-            if len(setting) == 1:
+            # (<section>, <option>)
+            if length == 2:
+                invalid_settings.append(f'{setting[0]}/{setting[1]}')
                 continue
-
-            # (<section>, <option>) or (<section>, <option>, <admissible>)
-            section, option = setting[:2]
-            if not self.has_option(section, option):
-                invalid_settings.append(f'{section}/{option}')
-                continue
-
             # (<section>, <option>, <admissible>)
-            if len(setting) == 3:
-                admissible_values = setting[2]
-                if self[section][option] not in admissible_values:
-                    invalid_settings.append(
-                        '/'.join(setting[:2])
-                        + ' not one of ' + ', '.join(admissible_values)
-                        )
+            invalid_settings.append('/'.join(setting[:2]) + ' not one of ' +
+                                    ', '.join(setting[2]))
         return invalid_settings
 
     def read(self, filenames, encoding=None):
@@ -871,10 +872,18 @@ class SystemSettings(ViPErLEEDSettings):
 
         # We're missing settings. Let's add them back...
         for missing in invalid:
-            section, option = missing.split('/')
+            # 1. Strip off the value-error suffix if present
+            clean_keys = missing.split(' not one of ')[0]
+            if '/' in clean_keys:
+                section, option = clean_keys.split('/')
+            else:
+                # Only section is missing, no option
+                section = clean_keys
+                option = None
             if section not in self:
                 self.add_section(section)
-            self.set(section, option, '')
+            if option:
+                self.set(section, option, '')
 
         if invalid:
             # ...and save changes

--- a/src/viperleed/gui/measure/measurement/abc.py
+++ b/src/viperleed/gui/measure/measurement/abc.py
@@ -390,9 +390,7 @@ class MeasurementABC(QObjectWithSettingsABC):                                   
             specify additional information on what is wrong with each
             invalid setting.
         """
-        invalid_ramp_settings = EnergyRampABC.are_settings_invalid(
-            settings
-            )
+        invalid_ramp_settings = EnergyRampABC.are_settings_invalid(settings)
 
         invalid_settings = settings.misses_settings(
             *self._mandatory_settings,

--- a/tests/gui/measure/classes/test_settings.py
+++ b/tests/gui/measure/classes/test_settings.py
@@ -360,19 +360,6 @@ class TestViPErLEEDSettings:
         )
         assert not invalid
 
-    def test_missing_section(self):
-        """Check reporting when a section is missing."""
-        parser = ViPErLEEDSettings(cls_name='Foo')
-        invalid = parser.misses_settings(('MissingSec',))
-        assert invalid == ['MissingSec']
-
-    def test_missing_option(self):
-        """Check reporting when an option within a section is missing."""
-        parser = ViPErLEEDSettings(cls_name='Foo')
-        parser.read_dict({'Sec': {}})
-        invalid = parser.misses_settings(('Sec', 'MissingOpt'))
-        assert invalid == ['Sec/MissingOpt']
-
     def test_invalid_admissible_value(self):
         """Check reporting when an option is not in admissible_values."""
         parser = ViPErLEEDSettings(cls_name='Foo')
@@ -386,3 +373,16 @@ class TestViPErLEEDSettings:
         parser = ViPErLEEDSettings(cls_name='Foo')
         with pytest.raises(TypeError):
             parser.misses_settings(bad_setting)
+
+    def test_missing_option(self):
+        """Check reporting when an option within a section is missing."""
+        parser = ViPErLEEDSettings(cls_name='Foo')
+        parser.read_dict({'Sec': {}})
+        invalid = parser.misses_settings(('Sec', 'MissingOpt'))
+        assert invalid == ['Sec/MissingOpt']
+
+    def test_missing_section(self):
+        """Check reporting when a section is missing."""
+        parser = ViPErLEEDSettings(cls_name='Foo')
+        invalid = parser.misses_settings(('MissingSec',))
+        assert invalid == ['MissingSec']

--- a/tests/gui/measure/classes/test_settings.py
+++ b/tests/gui/measure/classes/test_settings.py
@@ -281,27 +281,9 @@ fallback_values = (('A/opt2', 'cfb'),)
         parser.read_string(f'[oldsection]\noption={expected}')
         assert parser['new_section']['new_option'] == expected
 
-# pylint: disable-next=too-few-public-methods
+
 class TestSystemSettings:
     """Tests for SystemSettings."""
-
-    def test_hidden_folder_and_settings_creation(self, tmp_path, mocker):
-        """Test whether the hidden folder and settings were created."""
-        fake_path = tmp_path / 'ViPErLEED' / 'Measurement.ini'
-        # Patch detected folder path to be in tmp_path.
-        mocker.patch('PyQt5.QtCore.QSettings.fileName',
-                     return_value=str(fake_path))
-        # Patch QSettings.allKeys to force creation of settings folder.
-        mocker.patch('PyQt5.QtCore.QSettings.allKeys', return_value=None)
-        sys_settings = SystemSettings()
-        # pylint: disable-next=protected-access
-        settings_path = Path(sys_settings._sys_qsettings.fileName()).resolve()
-        assert settings_path.parent.is_dir()
-        assert settings_path.is_file()
-
-
-class TestCheckMandatorySettings:
-    """Tests for _check_mandatory_settings behavior."""
 
     @fixture
     def settings(self, tmp_path, mocker):
@@ -335,6 +317,20 @@ class TestCheckMandatorySettings:
         assert settings.has_section('SecB')
         settings.update_file.assert_called_once()
 
+    def test_hidden_folder_and_settings_creation(self, tmp_path, mocker):
+        """Test whether the hidden folder and settings were created."""
+        fake_path = tmp_path / 'ViPErLEED' / 'Measurement.ini'
+        # Patch detected folder path to be in tmp_path.
+        mocker.patch('PyQt5.QtCore.QSettings.fileName',
+                     return_value=str(fake_path))
+        # Patch QSettings.allKeys to force creation of settings folder.
+        mocker.patch('PyQt5.QtCore.QSettings.allKeys', return_value=None)
+        sys_settings = SystemSettings()
+        # pylint: disable-next=protected-access
+        settings_path = Path(sys_settings._sys_qsettings.fileName()).resolve()
+        assert settings_path.parent.is_dir()
+        assert settings_path.is_file()
+
     def test_raises_runtime_error_on_missing_mandatory(self, settings):
         """Check that RuntimeError is raised when mandatory settings fail."""
         settings._SystemSettings__non_null = []
@@ -346,8 +342,8 @@ class TestCheckMandatorySettings:
     # pylint: enable=protected-access
 
 
-class TestMissesSettings:
-    """Tests for the misses_settings method."""
+class TestViPErLEEDSettings:
+    """Tests for the ViPErLEEDSettings class."""
 
     def test_all_settings_valid(self):
         """Check that no invalid settings are returned when all exist."""

--- a/tests/gui/measure/classes/test_settings.py
+++ b/tests/gui/measure/classes/test_settings.py
@@ -350,7 +350,7 @@ class TestViPErLEEDSettings:
 
     def test_all_settings_valid(self):
         """Check that no invalid settings are returned when all exist."""
-        parser = ViPErLEEDSettings(cls_name='Foo')
+        parser = ViPErLEEDSettings()
         parser.read_dict({'Sec': {'opt1': 'val1', 'opt2': 'a'}})
 
         invalid = parser.misses_settings(
@@ -362,7 +362,7 @@ class TestViPErLEEDSettings:
 
     def test_invalid_admissible_value(self):
         """Check reporting when an option is not in admissible_values."""
-        parser = ViPErLEEDSettings(cls_name='Foo')
+        parser = ViPErLEEDSettings()
         parser.read_dict({'Sec': {'opt': 'wrong_val'}})
         invalid = parser.misses_settings(('Sec', 'opt', ['val1', 'val2']))
         assert invalid == ['Sec/opt not one of val1, val2']
@@ -370,19 +370,19 @@ class TestViPErLEEDSettings:
     @parametrize('bad_setting', [(), ('a', 'b', 'c', 'd')])
     def test_invalid_setting_format_raises(self, bad_setting):
         """Check that setting tuples with bad length raise TypeError."""
-        parser = ViPErLEEDSettings(cls_name='Foo')
+        parser = ViPErLEEDSettings()
         with pytest.raises(TypeError):
             parser.misses_settings(bad_setting)
 
     def test_missing_option(self):
         """Check reporting when an option within a section is missing."""
-        parser = ViPErLEEDSettings(cls_name='Foo')
+        parser = ViPErLEEDSettings()
         parser.read_dict({'Sec': {}})
         invalid = parser.misses_settings(('Sec', 'MissingOpt'))
         assert invalid == ['Sec/MissingOpt']
 
     def test_missing_section(self):
         """Check reporting when a section is missing."""
-        parser = ViPErLEEDSettings(cls_name='Foo')
+        parser = ViPErLEEDSettings()
         invalid = parser.misses_settings(('MissingSec',))
         assert invalid == ['MissingSec']

--- a/tests/gui/measure/classes/test_settings.py
+++ b/tests/gui/measure/classes/test_settings.py
@@ -19,6 +19,7 @@ import pytest
 
 from viperleed.gui.measure.classes.settings import AliasConfigParser
 from viperleed.gui.measure.classes.settings import SystemSettings
+from viperleed.gui.measure.classes.settings import ViPErLEEDSettings
 from viperleed.gui.measure.classes.settings import ensure_aliases_exist
 from viperleed.gui.measure.classes.settings import get_aliases_path
 from viperleed.gui.measure.classes.settings import interpolate_config_path
@@ -45,7 +46,9 @@ class TestEnsureAliasesExist:
         user_aliases = tmp_path / 'aliases.ini'
         user_aliases.write_text('[Foo]\nstays_user=stays1\nchanged=user')
         installed_aliases = ConfigParser()
-        installed_aliases.read_string('[Foo]\nstays_installed=stays2\nchanged=installed')
+        installed_aliases.read_string(
+            '[Foo]\nstays_installed=stays2\nchanged=installed'
+            )
         defaults = tmp_path / '_defaults'
         defaults.mkdir()
         with (defaults/'_aliases.ini').open('w') as installed_ini:
@@ -278,7 +281,7 @@ fallback_values = (('A/opt2', 'cfb'),)
         parser.read_string(f'[oldsection]\noption={expected}')
         assert parser['new_section']['new_option'] == expected
 
-
+# pylint: disable-next=too-few-public-methods
 class TestSystemSettings:
     """Tests for SystemSettings."""
 
@@ -291,6 +294,96 @@ class TestSystemSettings:
         # Patch QSettings.allKeys to force creation of settings folder.
         mocker.patch('PyQt5.QtCore.QSettings.allKeys', return_value=None)
         sys_settings = SystemSettings()
+        # pylint: disable-next=protected-access
         settings_path = Path(sys_settings._sys_qsettings.fileName()).resolve()
         assert settings_path.parent.is_dir()
         assert settings_path.is_file()
+
+
+class TestCheckMandatorySettings:
+    """Tests for _check_mandatory_settings behavior."""
+
+    @fixture
+    def settings(self, tmp_path, mocker):
+        """Create a mock SystemSettings instance pointing to a tmp file."""
+        fake_path = tmp_path / 'settings.ini'
+        fake_qs = mocker.Mock()
+        fake_qs.fileName.return_value = str(fake_path)
+        fake_qs.childGroups.return_value = []
+        fake_qs.childKeys.return_value = []
+        fake_qs.allKeys.return_value = []
+        fake_qs.value.return_value = ''
+
+        mocker.patch(f'{_MODULE}.get_qsettings', return_value=fake_qs)
+        sys_settings = SystemSettings()
+        mocker.patch.object(sys_settings, 'update_file')
+        return sys_settings
+
+    # pylint: disable=protected-access
+    def test_auto_fills_missing_non_null_settings(self, settings):
+        """Check that missing settings are auto-created."""
+        # Define requirements
+        settings._SystemSettings__non_null = [('SecA', 'opt1')]
+        settings._SystemSettings__non_mandatory = [('SecB',)]
+        settings._SystemSettings__mandatory = []
+        settings._check_mandatory_settings()
+
+        # Check auto-creation
+        assert settings.has_section('SecA')
+        assert settings.has_option('SecA', 'opt1')
+        assert settings.get('SecA', 'opt1') == ''   # pylint: disable=C1804
+        assert settings.has_section('SecB')
+        settings.update_file.assert_called_once()
+
+    def test_raises_runtime_error_on_missing_mandatory(self, settings):
+        """Check that RuntimeError is raised when mandatory settings fail."""
+        settings._SystemSettings__non_null = []
+        settings._SystemSettings__non_mandatory = []
+        settings._SystemSettings__mandatory = [('MandatorySec', 'opt')]
+
+        with pytest.raises(RuntimeError, match='MandatorySec/opt'):
+            settings._check_mandatory_settings()
+    # pylint: enable=protected-access
+
+
+class TestMissesSettings:
+    """Tests for the misses_settings method."""
+
+    def test_all_settings_valid(self):
+        """Check that no invalid settings are returned when all exist."""
+        parser = ViPErLEEDSettings(cls_name='Foo')
+        parser.read_dict({'Sec': {'opt1': 'val1', 'opt2': 'a'}})
+
+        invalid = parser.misses_settings(
+            ('Sec',),
+            ('Sec', 'opt1'),
+            ('Sec', 'opt2', ['a', 'b'])
+        )
+        assert invalid == []    # pylint: disable=C1803
+
+    def test_missing_section(self):
+        """Check reporting when a section is missing."""
+        parser = ViPErLEEDSettings(cls_name='Foo')
+        invalid = parser.misses_settings(('MissingSec',))
+        assert invalid == ['MissingSec']
+
+    def test_missing_option(self):
+        """Check reporting when an option within a section is missing."""
+        parser = ViPErLEEDSettings(cls_name='Foo')
+        parser.read_dict({'Sec': {}})
+        invalid = parser.misses_settings(('Sec', 'MissingOpt'))
+        assert invalid == ['Sec/MissingOpt']
+
+    def test_invalid_admissible_value(self):
+        """Check reporting when an option is not in admissible_values."""
+        parser = ViPErLEEDSettings(cls_name='Foo')
+        parser.read_dict({'Sec': {'opt': 'wrong_val'}})
+        invalid = parser.misses_settings(('Sec', 'opt', ['val1', 'val2']))
+        assert invalid == ['Sec/opt not one of val1, val2']
+
+    @parametrize('bad_setting', [(), ('a', 'b', 'c', 'd')])
+    def test_invalid_setting_format_raises(self, bad_setting):
+        """Check that setting tuples with bad length raise TypeError."""
+        parser = ViPErLEEDSettings(cls_name='Foo')
+        with pytest.raises(TypeError):
+            parser.misses_settings(bad_setting)

--- a/tests/gui/measure/classes/test_settings.py
+++ b/tests/gui/measure/classes/test_settings.py
@@ -359,7 +359,7 @@ class TestMissesSettings:
             ('Sec', 'opt1'),
             ('Sec', 'opt2', ['a', 'b'])
         )
-        assert invalid == []    # pylint: disable=C1803
+        assert not invalid
 
     def test_missing_section(self):
         """Check reporting when a section is missing."""

--- a/tests/gui/measure/classes/test_settings.py
+++ b/tests/gui/measure/classes/test_settings.py
@@ -301,13 +301,15 @@ class TestSystemSettings:
         mocker.patch.object(sys_settings, 'update_file')
         return sys_settings
 
-    # pylint: disable=protected-access
-    def test_auto_fills_missing_non_null_settings(self, settings):
+    def test_auto_fills_missing_non_null_settings(self, settings, mocker):
         """Check that missing settings are auto-created."""
         # Define requirements
-        settings._SystemSettings__non_null = [('SecA', 'opt1')]
-        settings._SystemSettings__non_mandatory = [('SecB',)]
-        settings._SystemSettings__mandatory = []
+        mocker.patch.object(settings, '_SystemSettings__non_null',
+                            [('SecA', 'opt1')])
+        mocker.patch.object(settings, '_SystemSettings__non_mandatory',
+                            [('SecB',)])
+        mocker.patch.object(settings, '_SystemSettings__mandatory', [])
+        # pylint: disable-next=protected-access
         settings._check_mandatory_settings()
 
         # Check auto-creation
@@ -331,15 +333,16 @@ class TestSystemSettings:
         assert settings_path.parent.is_dir()
         assert settings_path.is_file()
 
-    def test_raises_runtime_error_on_missing_mandatory(self, settings):
+    def test_raises_runtime_error_on_missing_mandatory(self, settings, mocker):
         """Check that RuntimeError is raised when mandatory settings fail."""
-        settings._SystemSettings__non_null = []
-        settings._SystemSettings__non_mandatory = []
-        settings._SystemSettings__mandatory = [('MandatorySec', 'opt')]
+        mocker.patch.object(settings, '_SystemSettings__non_null', [])
+        mocker.patch.object(settings, '_SystemSettings__non_mandatory', [])
+        mocker.patch.object(settings, '_SystemSettings__mandatory',
+                            [('MandatorySec', 'opt')])
 
         with pytest.raises(RuntimeError, match='MandatorySec/opt'):
+            # pylint: disable-next=protected-access
             settings._check_mandatory_settings()
-    # pylint: enable=protected-access
 
 
 class TestViPErLEEDSettings:


### PR DESCRIPTION
Fix `misses_settings` and `_check_mandatory_settings` of `ViPErLEEDSettings`. The previous implementation would falsely report missing section/option pairs as just missing sections if the section was missing. Furthermore, the section/option/value handling was broken.