### PR TITLE
Add support for the py3.14 Configparser

### DIFF
--- a/src/viperleed/gui/measure/classes/settings.py
+++ b/src/viperleed/gui/measure/classes/settings.py
@@ -705,7 +705,7 @@ class ViPErLEEDSettings(AliasConfigParser):
         fp.write('\n')
 
     def _make_comment_regex(self):
-        """Extract and return the comment prefixes of self."""
+        """Return a regular expression for matching comments."""
         # Note that we currently pass kwargs['comment_prefixes'] = '#;'
         # on __init__, which means the comment prefixes will always be
         # # and ; at the time of writing (Py 3.15 and before).

--- a/src/viperleed/gui/measure/classes/settings.py
+++ b/src/viperleed/gui/measure/classes/settings.py
@@ -29,6 +29,7 @@ from collections.abc import Sequence
 import copy
 import os
 from pathlib import Path
+import re
 import sys
 
 from wrapt import synchronized  # thread-safety decorator
@@ -722,10 +723,17 @@ class ViPErLEEDSettings(AliasConfigParser):
             True if the line was a comment (whether it was stored
             or not).
         """
+        prefixes = None
         try:
             prefixes = self._comment_prefixes  # < PY3_13
         except AttributeError:
-            prefixes = self._prefixes.full
+            try:
+                prefixes = self._prefixes.full # = PY3_13
+            except AttributeError:
+                pass
+        if not prefixes:
+            prefixes = re.findall(r'\^\(\\?(.?)\)',
+                                  self._comments.pattern.pattern) # > PY3_13
         for prefix in prefixes:
             if line.strip().startswith(prefix):
                 if line not in self.__comments[sectname]:

--- a/src/viperleed/gui/measure/classes/settings.py
+++ b/src/viperleed/gui/measure/classes/settings.py
@@ -723,7 +723,7 @@ class ViPErLEEDSettings(AliasConfigParser):
             pattern = '|'.join(fr'^\s*({p})' for p in escaped)
             self.__prefixes = re.compile(pattern)
             return
-        self.__prefixes = self._comments.pattern
+        self.__prefixes = self._comments.pattern    # pylint: disable=no-member
 
     def __store_if_comment(self, line, sectname):
         """Store a line as comment if it is one.
@@ -745,7 +745,7 @@ class ViPErLEEDSettings(AliasConfigParser):
             True if the line was a comment (whether it was stored
             or not).
         """
-        if self.__prefixes.match(line):
+        if self.__prefixes.match(line.strip()):
             if line not in self.__comments[sectname]:
                 self.__comments[sectname].append(line)
             return True

--- a/src/viperleed/gui/measure/classes/settings.py
+++ b/src/viperleed/gui/measure/classes/settings.py
@@ -315,7 +315,7 @@ class ViPErLEEDSettings(AliasConfigParser):
         # when the content of the config was read from an archive.
         self._last_file = ''
         self.__base_dir = ''
-        self.__store_comment_prefixes()
+        self.__comment_re = self._make_comment_regex()
 
     def __str__(self):
         """Return a simple string representation of self."""
@@ -704,8 +704,8 @@ class ViPErLEEDSettings(AliasConfigParser):
             fp.write(f'{key}{value}\n')
         fp.write('\n')
 
-    def __store_comment_prefixes(self):
-        """Extract and store the comment prefixes of self."""
+    def _make_comment_regex(self):
+        """Extract and return the comment prefixes of self."""
         # Note that we currently pass kwargs['comment_prefixes'] = '#;'
         # on __init__, which means the comment prefixes will always be
         # # and ; at the time of writing (Py 3.15 and before).
@@ -719,11 +719,10 @@ class ViPErLEEDSettings(AliasConfigParser):
                 pass
         if prefixes:
             # Build regex pattern to match comment lines
-            escaped = [re.escape(p) for p in prefixes]
-            pattern = '|'.join(fr'^\s*({p})' for p in escaped)
-            self.__prefixes = re.compile(pattern)
-            return
-        self.__prefixes = self._comments.pattern    # pylint: disable=no-member
+            escaped = (re.escape(p) for p in prefixes)
+            pattern = '|'.join(fr'^\s*{p}' for p in escaped)
+            return re.compile(pattern)
+        return self._comments.pattern   # pylint: disable=no-member
 
     def __store_if_comment(self, line, sectname):
         """Store a line as comment if it is one.
@@ -745,7 +744,7 @@ class ViPErLEEDSettings(AliasConfigParser):
             True if the line was a comment (whether it was stored
             or not).
         """
-        if self.__prefixes.match(line.strip()):
+        if self.__comment_re.match(line.strip()):
             if line not in self.__comments[sectname]:
                 self.__comments[sectname].append(line)
             return True

--- a/src/viperleed/gui/measure/classes/settings.py
+++ b/src/viperleed/gui/measure/classes/settings.py
@@ -315,6 +315,7 @@ class ViPErLEEDSettings(AliasConfigParser):
         # when the content of the config was read from an archive.
         self._last_file = ''
         self.__base_dir = ''
+        self.__store_comment_prefixes()
 
     def __str__(self):
         """Return a simple string representation of self."""
@@ -703,6 +704,27 @@ class ViPErLEEDSettings(AliasConfigParser):
             fp.write(f'{key}{value}\n')
         fp.write('\n')
 
+    def __store_comment_prefixes(self):
+        """Extract and store the comment prefixes of self."""
+        # Note that we currently pass kwargs['comment_prefixes'] = '#;'
+        # on __init__, which means the comment prefixes will always be
+        # # and ; at the time of writing (Py 3.15 and before).
+        prefixes = None
+        try:
+            prefixes = self._comment_prefixes  # < PY3_13
+        except AttributeError:
+            try:
+                prefixes = self._prefixes.full # = PY3_13
+            except AttributeError:
+                pass
+        if prefixes:
+            # Build regex pattern to match comment lines
+            escaped = [re.escape(p) for p in prefixes]
+            pattern = '|'.join(fr'^\s*({p})' for p in escaped)
+            self.__prefixes = re.compile(pattern)
+            return
+        self.__prefixes = self._comments.pattern
+
     def __store_if_comment(self, line, sectname):
         """Store a line as comment if it is one.
 
@@ -723,22 +745,10 @@ class ViPErLEEDSettings(AliasConfigParser):
             True if the line was a comment (whether it was stored
             or not).
         """
-        prefixes = None
-        try:
-            prefixes = self._comment_prefixes  # < PY3_13
-        except AttributeError:
-            try:
-                prefixes = self._prefixes.full # = PY3_13
-            except AttributeError:
-                pass
-        if not prefixes:
-            prefixes = re.findall(r'\^\(\\?(.?)\)',
-                                  self._comments.pattern.pattern) # > PY3_13
-        for prefix in prefixes:
-            if line.strip().startswith(prefix):
-                if line not in self.__comments[sectname]:
-                    self.__comments[sectname].append(line)
-                return True
+        if self.__prefixes.match(line):
+            if line not in self.__comments[sectname]:
+                self.__comments[sectname].append(line)
+            return True
         return False
 
 

--- a/tests/gui/measure/classes/test_settings.py
+++ b/tests/gui/measure/classes/test_settings.py
@@ -394,11 +394,11 @@ class TestViPErLEEDSettings:
         """Check that both # and ; prefixes are matched."""
         parser = ViPErLEEDSettings()
         # pylint: disable-next=protected-access
-        pattern = parser._ViPErLEEDSettings__prefixes
+        pattern = parser._ViPErLEEDSettings__comment_re
 
-        assert pattern.match('# comment') is not None
-        assert pattern.match('; comment') is not None
-        assert pattern.match('not a comment') is None
+        assert pattern.match('# comment')
+        assert pattern.match('; comment')
+        assert not pattern.match('not a comment')
 
     def test_invalid_admissible_value(self):
         """Check reporting when an option is not in admissible_values."""

--- a/tests/gui/measure/classes/test_settings.py
+++ b/tests/gui/measure/classes/test_settings.py
@@ -375,14 +375,6 @@ class TestViPErLEEDSettings:
         comments = parser._ViPErLEEDSettings__comments['TestSection']
         assert comments.count(comment_line) == 1
 
-    def test_comment_prefixes_regex_created(self):
-        """Check that comment prefixes regex is created correctly."""
-        parser = ViPErLEEDSettings()
-        # pylint: disable-next=protected-access
-        assert parser._ViPErLEEDSettings__prefixes is not None
-        # pylint: disable-next=protected-access
-        assert hasattr(parser._ViPErLEEDSettings__prefixes, 'pattern')
-
     def test_comments_stored_by_section(self):
         """Check that comments are stored under the correct section."""
         parser = ViPErLEEDSettings()

--- a/tests/gui/measure/classes/test_settings.py
+++ b/tests/gui/measure/classes/test_settings.py
@@ -360,6 +360,54 @@ class TestViPErLEEDSettings:
         )
         assert not invalid
 
+    def test_duplicate_comments_not_stored(self):
+        """Check that duplicate comment lines are not stored twice."""
+        parser = ViPErLEEDSettings()
+        comment_line = '# Duplicate comment'
+        # pylint: disable-next=protected-access
+        parser._ViPErLEEDSettings__store_if_comment(comment_line,
+                                                    'TestSection')
+        # pylint: disable-next=protected-access
+        parser._ViPErLEEDSettings__store_if_comment(comment_line,
+                                                    'TestSection')
+
+        # pylint: disable-next=protected-access
+        comments = parser._ViPErLEEDSettings__comments['TestSection']
+        assert comments.count(comment_line) == 1
+
+    def test_comment_prefixes_regex_created(self):
+        """Check that comment prefixes regex is created correctly."""
+        parser = ViPErLEEDSettings()
+        # pylint: disable-next=protected-access
+        assert parser._ViPErLEEDSettings__prefixes is not None
+        # pylint: disable-next=protected-access
+        assert hasattr(parser._ViPErLEEDSettings__prefixes, 'pattern')
+
+    def test_comments_stored_by_section(self):
+        """Check that comments are stored under the correct section."""
+        parser = ViPErLEEDSettings()
+        before_sec = '# Comment before section'
+        in_sec = '# Comment in section'
+        # pylint: disable-next=protected-access
+        parser._ViPErLEEDSettings__store_if_comment(before_sec, None)
+        # pylint: disable-next=protected-access
+        parser._ViPErLEEDSettings__store_if_comment(in_sec, 'MySection')
+
+        # pylint: disable-next=protected-access
+        comments = parser._ViPErLEEDSettings__comments
+        assert before_sec in comments[None]
+        assert in_sec in comments['MySection']
+
+    def test_comment_regex_matches_both_prefixes(self):
+        """Check that both # and ; prefixes are matched."""
+        parser = ViPErLEEDSettings()
+        # pylint: disable-next=protected-access
+        pattern = parser._ViPErLEEDSettings__prefixes
+
+        assert pattern.match('# comment') is not None
+        assert pattern.match('; comment') is not None
+        assert pattern.match('not a comment') is None
+
     def test_invalid_admissible_value(self):
         """Check reporting when an option is not in admissible_values."""
         parser = ViPErLEEDSettings()
@@ -386,3 +434,22 @@ class TestViPErLEEDSettings:
         parser = ViPErLEEDSettings()
         invalid = parser.misses_settings(('MissingSec',))
         assert invalid == ['MissingSec']
+
+    @parametrize('line,expected', [
+        ('# This is a comment', True),
+        ('; This is also a comment', True),
+        ('  # Comment with leading spaces', True),
+        ('  ; Comment with leading spaces', True),
+        ('not a comment', False),
+        ('option = value # inline', False),  # inline comments not supported
+        ('', False),
+        ('#', True),
+        (';', True),
+    ])
+    def test_store_if_comment(self, line, expected):
+        """Check correct identification of comment lines."""
+        parser = ViPErLEEDSettings()
+        # pylint: disable-next=protected-access
+        result = parser._ViPErLEEDSettings__store_if_comment(line,
+                                                             'TestSection')
+        assert result == expected


### PR DESCRIPTION
The Python 3.14 Configparser changed again how the comment prefixes are stored internally. This fix extracts them from the new implementation.